### PR TITLE
Move access checks to the COPY hook

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2672,6 +2672,9 @@ mod tests {
         let create_role = "create role test_role;";
         Spi::run(create_role).unwrap();
 
+        let grant_role = "grant pg_write_server_files TO test_role;";
+        Spi::run(grant_role).unwrap();
+
         let set_role = "set role test_role;";
         Spi::run(set_role).unwrap();
 

--- a/src/parquet_copy_hook/hook.rs
+++ b/src/parquet_copy_hook/hook.rs
@@ -7,7 +7,10 @@ use pg_sys::{
 use pgrx::{prelude::*, GucSetting};
 
 use crate::{
-    arrow_parquet::{compression::INVALID_COMPRESSION_LEVEL, uri_utils::uri_as_string},
+    arrow_parquet::{
+        compression::INVALID_COMPRESSION_LEVEL,
+        uri_utils::{ensure_access_privilege_to_uri, uri_as_string},
+    },
     parquet_copy_hook::{
         copy_to_dest_receiver::create_copy_to_parquet_dest_receiver,
         copy_utils::{
@@ -59,6 +62,9 @@ extern "C" fn parquet_copy_hook(
 
     if ENABLE_PARQUET_COPY_HOOK.get() && is_copy_to_parquet_stmt(&p_stmt) {
         let uri = copy_stmt_uri(&p_stmt).expect("uri is None");
+        let copy_from = false;
+
+        ensure_access_privilege_to_uri(&uri, copy_from);
 
         validate_copy_to_options(&p_stmt, &uri);
 
@@ -106,6 +112,9 @@ extern "C" fn parquet_copy_hook(
         return;
     } else if ENABLE_PARQUET_COPY_HOOK.get() && is_copy_from_parquet_stmt(&p_stmt) {
         let uri = copy_stmt_uri(&p_stmt).expect("uri is None");
+        let copy_from = true;
+
+        ensure_access_privilege_to_uri(&uri, copy_from);
 
         validate_copy_from_options(&p_stmt);
 

--- a/src/parquet_udfs/metadata.rs
+++ b/src/parquet_udfs/metadata.rs
@@ -1,7 +1,9 @@
 use ::parquet::file::statistics::Statistics;
 use pgrx::{iter::TableIterator, name, pg_extern, pg_schema};
 
-use crate::arrow_parquet::uri_utils::{parquet_metadata_from_uri, parse_uri, uri_as_string};
+use crate::arrow_parquet::uri_utils::{
+    ensure_access_privilege_to_uri, parquet_metadata_from_uri, parse_uri, uri_as_string,
+};
 
 #[pg_schema]
 mod parquet {
@@ -39,6 +41,7 @@ mod parquet {
     > {
         let uri = parse_uri(&uri);
 
+        ensure_access_privilege_to_uri(&uri, true);
         let parquet_metadata = parquet_metadata_from_uri(&uri);
 
         let mut rows = vec![];
@@ -137,6 +140,7 @@ mod parquet {
     > {
         let uri = parse_uri(&uri);
 
+        ensure_access_privilege_to_uri(&uri, true);
         let parquet_metadata = parquet_metadata_from_uri(&uri);
 
         let created_by = parquet_metadata
@@ -174,6 +178,7 @@ mod parquet {
     > {
         let uri = parse_uri(&uri);
 
+        ensure_access_privilege_to_uri(&uri, true);
         let parquet_metadata = parquet_metadata_from_uri(&uri);
         let kv_metadata = parquet_metadata.file_metadata().key_value_metadata();
 

--- a/src/parquet_udfs/schema.rs
+++ b/src/parquet_udfs/schema.rs
@@ -1,4 +1,6 @@
-use crate::arrow_parquet::uri_utils::{parquet_schema_from_uri, parse_uri, uri_as_string};
+use crate::arrow_parquet::uri_utils::{
+    ensure_access_privilege_to_uri, parquet_schema_from_uri, parse_uri, uri_as_string,
+};
 
 use ::parquet::{
     format::{ConvertedType, FieldRepetitionType, LogicalType, Type},
@@ -32,6 +34,7 @@ mod parquet {
     > {
         let uri = parse_uri(&uri);
 
+        ensure_access_privilege_to_uri(&uri, true);
         let parquet_schema = parquet_schema_from_uri(&uri);
 
         let root_type = parquet_schema.root_schema();


### PR DESCRIPTION
In order to allow low-level usage of the `DestReceiver` returned by `create_copy_parquet_dest_receiver()`, hoist the permissions checks into the actual COPY hook.  This allows DestReceiver consumers to perform their own checks/verifications rather than relying on the specifics herein.