### PR TITLE
Add pg{14,15} to support matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
       - name: Run tests
         run: |
           # Set up permissions so that the current user below can create extensions
-          sudo chmod a+rwx $(pg_config --pkglibdir) \
-            $(pg_config --sharedir)/extension \
+          sudo chmod a+rwx $(/usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config --pkglibdir) \
+            $(/usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config --sharedir)/extension \
             /var/run/postgresql/
 
           # pgrx tests with runas argument ignores environment variables, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        postgres: [ 16, 17 ]
+        postgres: [ 13, 14, 15, 16, 17 ]
     env:
       PG_MAJOR: ${{ matrix.postgres }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        postgres: [ 13, 14, 15, 16, 17 ]
+        postgres: [ 14, 15, 16, 17 ]
     env:
       PG_MAJOR: ${{ matrix.postgres }}
 
@@ -91,7 +91,7 @@ jobs:
       - name: Install and configure pgrx
         run: |
           cargo install --locked cargo-pgrx@0.12.6
-          cargo pgrx init --pg${{ env.PG_MAJOR }} /usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config
+          cargo pgrx init --pg${{ env.PG_MAJOR }} $(which pg_config)
 
       - name: Install cargo-llvm-cov for coverage report
         run: cargo install --locked cargo-llvm-cov@0.6.12
@@ -104,9 +104,9 @@ jobs:
       - name: Run tests
         run: |
           # Set up permissions so that the current user below can create extensions
-          sudo chmod a+rwx $(/usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config --pkglibdir) \
-            $(/usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config --sharedir)/extension \
-            /var/run/postgresql/
+          sudo chmod a+rwx $(pg_config --pkglibdir)          \
+                           $(pg_config --sharedir)/extension \
+                           /var/run/postgresql/
 
           # pgrx tests with runas argument ignores environment variables, so
           # we read env vars from .env file in tests (https://github.com/pgcentralfoundation/pgrx/pull/1674)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install and configure pgrx
         run: |
           cargo install --locked cargo-pgrx@0.12.6
-          cargo pgrx init --pg${{ env.PG_MAJOR }} $(which pg_config)
+          cargo pgrx init --pg${{ env.PG_MAJOR }} /usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config
 
       - name: Install cargo-llvm-cov for coverage report
         run: cargo install --locked cargo-llvm-cov@0.6.12

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
-pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg_test = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ path = "./src/bin/pgrx_embed.rs"
 
 [features]
 default = ["pg17"]
-pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
-pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg_test = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -235,8 +235,11 @@ There is currently only one GUC parameter to enable/disable the `pg_parquet`:
 > Any type that does not have a corresponding Parquet type will be represented, as a fallback mechanism, as `BYTE_ARRAY` with `STRING` logical type. e.g. `enum`
 
 ## Postgres Support Matrix
-`pg_parquet` is tested with the following PostgreSQL versions:
+`pg_parquet` supports the following PostgreSQL versions:
 | PostgreSQL Major Version | Supported |
 |--------------------------|-----------|
-| 17                       |    ✅     |
+| 13                       |    ✅     |
+| 14                       |    ✅     |
+| 15                       |    ✅     |
 | 16                       |    ✅     |
+| 17                       |    ✅     |

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ There is currently only one GUC parameter to enable/disable the `pg_parquet`:
 `pg_parquet` supports the following PostgreSQL versions:
 | PostgreSQL Major Version | Supported |
 |--------------------------|-----------|
-| 13                       |    ✅     |
 | 14                       |    ✅     |
 | 15                       |    ✅     |
 | 16                       |    ✅     |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use parquet_copy_hook::hook::{init_parquet_copy_hook, ENABLE_PARQUET_COPY_HOOK};
-use pg_sys::{AsPgCStr, MarkGUCPrefixReserved};
+use parquet_copy_hook::pg_compat::MarkGUCPrefixReserved;
 use pgrx::{prelude::*, GucContext, GucFlags, GucRegistry};
 
 mod arrow_parquet;
@@ -29,7 +29,7 @@ pub extern "C" fn _PG_init() {
         GucFlags::default(),
     );
 
-    unsafe { MarkGUCPrefixReserved("pg_parquet".as_pg_cstr()) };
+    MarkGUCPrefixReserved("pg_parquet");
 
     init_parquet_copy_hook();
 }

--- a/src/parquet_copy_hook.rs
+++ b/src/parquet_copy_hook.rs
@@ -3,3 +3,4 @@ pub(crate) mod copy_to;
 pub(crate) mod copy_to_dest_receiver;
 pub(crate) mod copy_utils;
 pub(crate) mod hook;
+pub(crate) mod pg_compat;

--- a/src/parquet_copy_hook/copy_from.rs
+++ b/src/parquet_copy_hook/copy_from.rs
@@ -5,8 +5,8 @@ use pgrx::{
     pg_sys::{
         addNSItemToQuery, assign_expr_collations, canonicalize_qual, check_enable_rls,
         coerce_to_boolean, eval_const_expressions, make_ands_implicit, transformExpr, AsPgCStr,
-        CheckEnableRlsResult, CopyFrom, CopyStmt, EndCopyFrom, InvalidOid, Node, Oid,
-        ParseExprKind, ParseNamespaceItem, ParseState, PlannedStmt, QueryEnvironment,
+        BeginCopyFrom, CheckEnableRlsResult, CopyFrom, CopyStmt, EndCopyFrom, InvalidOid, Node,
+        Oid, ParseExprKind, ParseNamespaceItem, ParseState, PlannedStmt, QueryEnvironment,
     },
     void_mut_ptr, PgBox, PgLogLevel, PgRelation, PgSqlErrorCode,
 };
@@ -19,12 +19,9 @@ use crate::{
     },
 };
 
-use super::{
-    copy_utils::{
-        copy_stmt_attribute_list, copy_stmt_create_namespace_item, copy_stmt_create_parse_state,
-        create_filtered_tupledesc_for_relation,
-    },
-    pg_compat::BeginCopyFrom,
+use super::copy_utils::{
+    copy_stmt_attribute_list, copy_stmt_create_namespace_item, copy_stmt_create_parse_state,
+    create_filtered_tupledesc_for_relation,
 };
 
 // stack to store parquet reader contexts for COPY FROM.
@@ -146,6 +143,8 @@ pub(crate) fn execute_copy_from(
             p_state.as_ptr(),
             relation.as_ptr(),
             where_clause,
+            std::ptr::null(),
+            false,
             Some(copy_parquet_data_to_buffer),
             attribute_list,
             copy_options.as_ptr(),

--- a/src/parquet_copy_hook/copy_from.rs
+++ b/src/parquet_copy_hook/copy_from.rs
@@ -5,8 +5,8 @@ use pgrx::{
     pg_sys::{
         addNSItemToQuery, assign_expr_collations, canonicalize_qual, check_enable_rls,
         coerce_to_boolean, eval_const_expressions, make_ands_implicit, transformExpr, AsPgCStr,
-        BeginCopyFrom, CheckEnableRlsResult, CopyFrom, CopyStmt, EndCopyFrom, InvalidOid, Node,
-        Oid, ParseExprKind, ParseNamespaceItem, ParseState, PlannedStmt, QueryEnvironment,
+        CheckEnableRlsResult, CopyFrom, CopyStmt, EndCopyFrom, InvalidOid, Node, Oid,
+        ParseExprKind, ParseNamespaceItem, ParseState, PlannedStmt, QueryEnvironment,
     },
     void_mut_ptr, PgBox, PgLogLevel, PgRelation, PgSqlErrorCode,
 };
@@ -19,9 +19,12 @@ use crate::{
     },
 };
 
-use super::copy_utils::{
-    copy_stmt_attribute_list, copy_stmt_create_namespace_item, copy_stmt_create_parse_state,
-    create_filtered_tupledesc_for_relation,
+use super::{
+    copy_utils::{
+        copy_stmt_attribute_list, copy_stmt_create_namespace_item, copy_stmt_create_parse_state,
+        create_filtered_tupledesc_for_relation,
+    },
+    pg_compat::BeginCopyFrom,
 };
 
 // stack to store parquet reader contexts for COPY FROM.
@@ -104,32 +107,32 @@ extern "C" fn copy_parquet_data_to_buffer(
 // 3. Calls the executor's CopyFrom function to read data from the parquet file and write
 //    it to the copy buffer.
 pub(crate) fn execute_copy_from(
-    p_stmt: PgBox<PlannedStmt>,
+    p_stmt: &PgBox<PlannedStmt>,
     query_string: &CStr,
-    query_env: PgBox<QueryEnvironment>,
+    query_env: &PgBox<QueryEnvironment>,
     uri: Url,
 ) -> u64 {
-    let rel_oid = copy_stmt_relation_oid(&p_stmt);
+    let rel_oid = copy_stmt_relation_oid(p_stmt);
 
     copy_from_stmt_ensure_row_level_security(rel_oid);
 
-    let lock_mode = copy_stmt_lock_mode(&p_stmt);
+    let lock_mode = copy_stmt_lock_mode(p_stmt);
 
     let relation = unsafe { PgRelation::with_lock(rel_oid, lock_mode) };
 
-    let p_state = copy_stmt_create_parse_state(query_string, &query_env);
+    let p_state = copy_stmt_create_parse_state(query_string, query_env);
 
-    let ns_item = copy_stmt_create_namespace_item(&p_stmt, &p_state, &relation);
+    let ns_item = copy_stmt_create_namespace_item(p_stmt, &p_state, &relation);
 
-    let mut where_clause = copy_from_stmt_where_clause(&p_stmt);
+    let mut where_clause = copy_from_stmt_where_clause(p_stmt);
 
     if !where_clause.is_null() {
         where_clause = copy_from_stmt_transform_where_clause(&p_state, &ns_item, where_clause);
     }
 
-    let attribute_list = copy_stmt_attribute_list(&p_stmt);
+    let attribute_list = copy_stmt_attribute_list(p_stmt);
 
-    let tupledesc = create_filtered_tupledesc_for_relation(&p_stmt, &relation);
+    let tupledesc = create_filtered_tupledesc_for_relation(p_stmt, &relation);
 
     unsafe {
         // parquet reader context is used throughout the COPY FROM operation.
@@ -137,14 +140,12 @@ pub(crate) fn execute_copy_from(
         push_parquet_reader_context(parquet_reader_context);
 
         // makes sure to set binary format
-        let copy_options = copy_from_stmt_create_option_list(&p_stmt);
+        let copy_options = copy_from_stmt_create_option_list(p_stmt);
 
         let copy_from_state = BeginCopyFrom(
             p_state.as_ptr(),
             relation.as_ptr(),
             where_clause,
-            std::ptr::null(),
-            false,
             Some(copy_parquet_data_to_buffer),
             attribute_list,
             copy_options.as_ptr(),

--- a/src/parquet_copy_hook/hook.rs
+++ b/src/parquet_copy_hook/hook.rs
@@ -43,6 +43,73 @@ pub(crate) extern "C" fn init_parquet_copy_hook() {
     }
 }
 
+fn process_copy_to_parquet(
+    p_stmt: &PgBox<PlannedStmt>,
+    query_string: &CStr,
+    params: &PgBox<ParamListInfoData>,
+    query_env: &PgBox<QueryEnvironment>,
+) -> u64 {
+    let uri = copy_stmt_uri(p_stmt).expect("uri is None");
+
+    let copy_from = false;
+    ensure_access_privilege_to_uri(&uri, copy_from);
+
+    validate_copy_to_options(p_stmt, &uri);
+
+    let row_group_size = copy_to_stmt_row_group_size(p_stmt);
+    let row_group_size_bytes = copy_to_stmt_row_group_size_bytes(p_stmt);
+    let compression = copy_to_stmt_compression(p_stmt, uri.clone());
+    let compression_level = copy_to_stmt_compression_level(p_stmt, uri.clone());
+
+    PgTryBuilder::new(|| {
+        let parquet_dest = create_copy_to_parquet_dest_receiver(
+            uri_as_string(&uri).as_pg_cstr(),
+            &row_group_size,
+            &row_group_size_bytes,
+            &compression,
+            &compression_level.unwrap_or(INVALID_COMPRESSION_LEVEL),
+        );
+
+        let parquet_dest = unsafe { PgBox::from_pg(parquet_dest) };
+
+        execute_copy_to_with_dest_receiver(p_stmt, query_string, params, query_env, parquet_dest)
+    })
+    .catch_others(|cause| {
+        // make sure to pop the parquet writer context
+        // In case we did not push the context, we should not throw an error while popping
+        let throw_error = false;
+        pop_parquet_writer_context(throw_error);
+
+        cause.rethrow()
+    })
+    .execute()
+}
+
+fn process_copy_from_parquet(
+    p_stmt: &PgBox<PlannedStmt>,
+    query_string: &CStr,
+    query_env: &PgBox<QueryEnvironment>,
+) -> u64 {
+    let uri = copy_stmt_uri(p_stmt).expect("uri is None");
+
+    let copy_from = true;
+    ensure_access_privilege_to_uri(&uri, copy_from);
+
+    validate_copy_from_options(p_stmt);
+
+    PgTryBuilder::new(|| execute_copy_from(p_stmt, query_string, query_env, uri))
+        .catch_others(|cause| {
+            // make sure to pop the parquet reader context
+            // In case we did not push the context, we should not throw an error while popping
+            let throw_error = false;
+            pop_parquet_reader_context(throw_error);
+
+            cause.rethrow()
+        })
+        .execute()
+}
+
+#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
 #[pg_guard]
 #[allow(clippy::too_many_arguments)]
 extern "C" fn parquet_copy_hook(
@@ -59,85 +126,23 @@ extern "C" fn parquet_copy_hook(
     let query_string = unsafe { CStr::from_ptr(query_string) };
     let params = unsafe { PgBox::from_pg(params) };
     let query_env = unsafe { PgBox::from_pg(query_env) };
+    let mut completion_tag = unsafe { PgBox::from_pg(completion_tag) };
 
     if ENABLE_PARQUET_COPY_HOOK.get() && is_copy_to_parquet_stmt(&p_stmt) {
-        let uri = copy_stmt_uri(&p_stmt).expect("uri is None");
-        let copy_from = false;
+        let nprocessed = process_copy_to_parquet(&p_stmt, query_string, &params, &query_env);
 
-        ensure_access_privilege_to_uri(&uri, copy_from);
-
-        validate_copy_to_options(&p_stmt, &uri);
-
-        let row_group_size = copy_to_stmt_row_group_size(&p_stmt);
-        let row_group_size_bytes = copy_to_stmt_row_group_size_bytes(&p_stmt);
-        let compression = copy_to_stmt_compression(&p_stmt, uri.clone());
-        let compression_level = copy_to_stmt_compression_level(&p_stmt, uri.clone());
-
-        PgTryBuilder::new(|| {
-            let parquet_dest = create_copy_to_parquet_dest_receiver(
-                uri_as_string(&uri).as_pg_cstr(),
-                &row_group_size,
-                &row_group_size_bytes,
-                &compression,
-                &compression_level.unwrap_or(INVALID_COMPRESSION_LEVEL),
-            );
-
-            let parquet_dest = unsafe { PgBox::from_pg(parquet_dest) };
-
-            let nprocessed = execute_copy_to_with_dest_receiver(
-                &p_stmt,
-                query_string,
-                params,
-                query_env,
-                parquet_dest,
-            );
-
-            let mut completion_tag = unsafe { PgBox::from_pg(completion_tag) };
-
-            if !completion_tag.is_null() {
-                completion_tag.nprocessed = nprocessed;
-                completion_tag.commandTag = CommandTag::CMDTAG_COPY;
-            }
-        })
-        .catch_others(|cause| {
-            // make sure to pop the parquet writer context
-            // In case we did not push the context, we should not throw an error while popping
-            let throw_error = false;
-            pop_parquet_writer_context(throw_error);
-
-            cause.rethrow()
-        })
-        .execute();
-
+        if !completion_tag.is_null() {
+            completion_tag.nprocessed = nprocessed;
+            completion_tag.commandTag = CommandTag::CMDTAG_COPY;
+        }
         return;
     } else if ENABLE_PARQUET_COPY_HOOK.get() && is_copy_from_parquet_stmt(&p_stmt) {
-        let uri = copy_stmt_uri(&p_stmt).expect("uri is None");
-        let copy_from = true;
+        let nprocessed = process_copy_from_parquet(&p_stmt, query_string, &query_env);
 
-        ensure_access_privilege_to_uri(&uri, copy_from);
-
-        validate_copy_from_options(&p_stmt);
-
-        PgTryBuilder::new(|| {
-            let nprocessed = execute_copy_from(p_stmt, query_string, query_env, uri);
-
-            let mut completion_tag = unsafe { PgBox::from_pg(completion_tag) };
-
-            if !completion_tag.is_null() {
-                completion_tag.nprocessed = nprocessed;
-                completion_tag.commandTag = CommandTag::CMDTAG_COPY;
-            }
-        })
-        .catch_others(|cause| {
-            // make sure to pop the parquet reader context
-            // In case we did not push the context, we should not throw an error while popping
-            let throw_error = false;
-            pop_parquet_reader_context(throw_error);
-
-            cause.rethrow()
-        })
-        .execute();
-
+        if !completion_tag.is_null() {
+            completion_tag.nprocessed = nprocessed;
+            completion_tag.commandTag = CommandTag::CMDTAG_COPY;
+        }
         return;
     }
 
@@ -151,7 +156,7 @@ extern "C" fn parquet_copy_hook(
                 params.into_pg(),
                 query_env.into_pg(),
                 dest,
-                completion_tag,
+                completion_tag.into_pg(),
             )
         } else {
             standard_ProcessUtility(
@@ -162,7 +167,68 @@ extern "C" fn parquet_copy_hook(
                 params.into_pg(),
                 query_env.into_pg(),
                 dest,
-                completion_tag,
+                completion_tag.into_pg(),
+            )
+        }
+    }
+}
+
+#[cfg(feature = "pg13")]
+#[pg_guard]
+#[allow(clippy::too_many_arguments)]
+extern "C" fn parquet_copy_hook(
+    p_stmt: *mut PlannedStmt,
+    query_string: *const c_char,
+    context: u32,
+    params: *mut ParamListInfoData,
+    query_env: *mut QueryEnvironment,
+    dest: *mut DestReceiver,
+    completion_tag: *mut QueryCompletion,
+) {
+    let p_stmt = unsafe { PgBox::from_pg(p_stmt) };
+    let query_string = unsafe { CStr::from_ptr(query_string) };
+    let params = unsafe { PgBox::from_pg(params) };
+    let query_env = unsafe { PgBox::from_pg(query_env) };
+    let mut completion_tag = unsafe { PgBox::from_pg(completion_tag) };
+
+    if ENABLE_PARQUET_COPY_HOOK.get() && is_copy_to_parquet_stmt(&p_stmt) {
+        let nprocessed = process_copy_to_parquet(&p_stmt, query_string, &params, &query_env);
+
+        if !completion_tag.is_null() {
+            completion_tag.nprocessed = nprocessed;
+            completion_tag.commandTag = CommandTag::CMDTAG_COPY;
+        }
+        return;
+    } else if ENABLE_PARQUET_COPY_HOOK.get() && is_copy_from_parquet_stmt(&p_stmt) {
+        let nprocessed = process_copy_from_parquet(&p_stmt, query_string, &query_env);
+
+        if !completion_tag.is_null() {
+            completion_tag.nprocessed = nprocessed;
+            completion_tag.commandTag = CommandTag::CMDTAG_COPY;
+        }
+        return;
+    }
+
+    unsafe {
+        if let Some(prev_hook) = PREV_PROCESS_UTILITY_HOOK {
+            prev_hook(
+                p_stmt.into_pg(),
+                query_string.as_ptr(),
+                context,
+                params.into_pg(),
+                query_env.into_pg(),
+                dest,
+                completion_tag.into_pg(),
+            )
+        } else {
+            standard_ProcessUtility(
+                p_stmt.into_pg(),
+                query_string.as_ptr(),
+                context,
+                params.into_pg(),
+                query_env.into_pg(),
+                dest,
+                completion_tag.into_pg(),
             )
         }
     }

--- a/src/parquet_copy_hook/pg_compat.rs
+++ b/src/parquet_copy_hook/pg_compat.rs
@@ -1,0 +1,153 @@
+use std::ffi::{c_char, CStr};
+
+use pgrx::{
+    datum::TimeWithTimeZone,
+    direct_function_call,
+    pg_sys::{
+        copy_data_source_cb, AsPgCStr, List, Node, ParseState, QueryEnvironment, RawStmt, Relation,
+    },
+    AnyNumeric, IntoDatum,
+};
+
+pub(crate) fn pg_analyze_and_rewrite(
+    raw_stmt: *mut RawStmt,
+    query_string: *const c_char,
+    query_env: *mut QueryEnvironment,
+) -> *mut List {
+    #[cfg(any(feature = "pg13", feature = "pg14"))]
+    unsafe {
+        pgrx::pg_sys::pg_analyze_and_rewrite(
+            raw_stmt,
+            query_string,
+            std::ptr::null_mut(),
+            0,
+            query_env,
+        )
+    }
+
+    #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17"))]
+    unsafe {
+        pgrx::pg_sys::pg_analyze_and_rewrite_fixedparams(
+            raw_stmt,
+            query_string,
+            std::ptr::null_mut(),
+            0,
+            query_env,
+        )
+    }
+}
+
+#[allow(non_snake_case)]
+pub(crate) fn strVal(val: *mut Node) -> String {
+    #[cfg(any(feature = "pg13", feature = "pg14"))]
+    unsafe {
+        let val = (*(val as *mut pgrx::pg_sys::Value)).val.str_;
+
+        CStr::from_ptr(val)
+            .to_str()
+            .expect("invalid string")
+            .to_string()
+    }
+
+    #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17"))]
+    unsafe {
+        let val = (*(val as *mut pgrx::pg_sys::String)).sval;
+
+        CStr::from_ptr(val)
+            .to_str()
+            .expect("invalid string")
+            .to_string()
+    }
+}
+
+#[cfg(feature = "pg13")]
+#[allow(non_snake_case)]
+pub(crate) fn BeginCopyFrom(
+    pstate: *mut ParseState,
+    relation: Relation,
+    _where_clause: *mut Node,
+    data_source_cb: copy_data_source_cb,
+    attribute_list: *mut List,
+    copy_options: *mut List,
+) -> *mut pgrx::pg_sys::CopyStateData {
+    unsafe {
+        pgrx::pg_sys::BeginCopyFrom(
+            pstate,
+            relation,
+            std::ptr::null(),
+            false,
+            data_source_cb,
+            attribute_list,
+            copy_options,
+        )
+    }
+}
+
+#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
+#[allow(non_snake_case)]
+pub(crate) fn BeginCopyFrom(
+    pstate: *mut ParseState,
+    relation: Relation,
+    _where_clause: *mut Node,
+    data_source_cb: copy_data_source_cb,
+    attribute_list: *mut List,
+    copy_options: *mut List,
+) -> *mut pgrx::pg_sys::CopyFromStateData {
+    unsafe {
+        pgrx::pg_sys::BeginCopyFrom(
+            pstate,
+            relation,
+            _where_clause,
+            std::ptr::null(),
+            false,
+            data_source_cb,
+            attribute_list,
+            copy_options,
+        )
+    }
+}
+
+pub(crate) fn extract_timezone_from_timetz(timetz: TimeWithTimeZone) -> f64 {
+    #[cfg(feature = "pg13")]
+    {
+        let timezone_as_secs: f64 = unsafe {
+            direct_function_call(
+                pgrx::pg_sys::timetz_part,
+                &["timezone".into_datum(), timetz.into_datum()],
+            )
+        }
+        .expect("cannot extract timezone from timetz");
+
+        timezone_as_secs
+    }
+
+    #[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
+    {
+        let timezone_as_secs: AnyNumeric = unsafe {
+            direct_function_call(
+                pgrx::pg_sys::extract_timetz,
+                &["timezone".into_datum(), timetz.into_datum()],
+            )
+        }
+        .expect("cannot extract timezone from timetz");
+
+        let timezone_as_secs: f64 = timezone_as_secs
+            .try_into()
+            .unwrap_or_else(|e| panic!("{}", e));
+
+        timezone_as_secs
+    }
+}
+
+#[allow(non_snake_case)]
+pub(crate) fn MarkGUCPrefixReserved(guc_prefix: &str) {
+    #[cfg(any(feature = "pg13", feature = "pg14"))]
+    unsafe {
+        pgrx::pg_sys::EmitWarningsOnPlaceholders(guc_prefix.as_pg_cstr())
+    }
+
+    #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17"))]
+    unsafe {
+        pgrx::pg_sys::MarkGUCPrefixReserved(guc_prefix.as_pg_cstr())
+    }
+}

--- a/src/parquet_copy_hook/pg_compat.rs
+++ b/src/parquet_copy_hook/pg_compat.rs
@@ -6,8 +6,11 @@ use pgrx::{
     pg_sys::{
         copy_data_source_cb, AsPgCStr, List, Node, ParseState, QueryEnvironment, RawStmt, Relation,
     },
-    AnyNumeric, IntoDatum,
+    IntoDatum,
 };
+
+#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
+use pgrx::AnyNumeric;
 
 pub(crate) fn pg_analyze_and_rewrite(
     raw_stmt: *mut RawStmt,

--- a/src/parquet_copy_hook/pg_compat.rs
+++ b/src/parquet_copy_hook/pg_compat.rs
@@ -1,23 +1,13 @@
 use std::ffi::{c_char, CStr};
 
-use pgrx::{
-    datum::TimeWithTimeZone,
-    direct_function_call,
-    pg_sys::{
-        copy_data_source_cb, AsPgCStr, List, Node, ParseState, QueryEnvironment, RawStmt, Relation,
-    },
-    IntoDatum,
-};
-
-#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
-use pgrx::AnyNumeric;
+use pgrx::pg_sys::{AsPgCStr, List, Node, QueryEnvironment, RawStmt};
 
 pub(crate) fn pg_analyze_and_rewrite(
     raw_stmt: *mut RawStmt,
     query_string: *const c_char,
     query_env: *mut QueryEnvironment,
 ) -> *mut List {
-    #[cfg(any(feature = "pg13", feature = "pg14"))]
+    #[cfg(feature = "pg14")]
     unsafe {
         pgrx::pg_sys::pg_analyze_and_rewrite(
             raw_stmt,
@@ -42,7 +32,7 @@ pub(crate) fn pg_analyze_and_rewrite(
 
 #[allow(non_snake_case)]
 pub(crate) fn strVal(val: *mut Node) -> String {
-    #[cfg(any(feature = "pg13", feature = "pg14"))]
+    #[cfg(feature = "pg14")]
     unsafe {
         let val = (*(val as *mut pgrx::pg_sys::Value)).val.str_;
 
@@ -63,88 +53,9 @@ pub(crate) fn strVal(val: *mut Node) -> String {
     }
 }
 
-#[cfg(feature = "pg13")]
-#[allow(non_snake_case)]
-pub(crate) fn BeginCopyFrom(
-    pstate: *mut ParseState,
-    relation: Relation,
-    _where_clause: *mut Node,
-    data_source_cb: copy_data_source_cb,
-    attribute_list: *mut List,
-    copy_options: *mut List,
-) -> *mut pgrx::pg_sys::CopyStateData {
-    unsafe {
-        pgrx::pg_sys::BeginCopyFrom(
-            pstate,
-            relation,
-            std::ptr::null(),
-            false,
-            data_source_cb,
-            attribute_list,
-            copy_options,
-        )
-    }
-}
-
-#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
-#[allow(non_snake_case)]
-pub(crate) fn BeginCopyFrom(
-    pstate: *mut ParseState,
-    relation: Relation,
-    _where_clause: *mut Node,
-    data_source_cb: copy_data_source_cb,
-    attribute_list: *mut List,
-    copy_options: *mut List,
-) -> *mut pgrx::pg_sys::CopyFromStateData {
-    unsafe {
-        pgrx::pg_sys::BeginCopyFrom(
-            pstate,
-            relation,
-            _where_clause,
-            std::ptr::null(),
-            false,
-            data_source_cb,
-            attribute_list,
-            copy_options,
-        )
-    }
-}
-
-pub(crate) fn extract_timezone_from_timetz(timetz: TimeWithTimeZone) -> f64 {
-    #[cfg(feature = "pg13")]
-    {
-        let timezone_as_secs: f64 = unsafe {
-            direct_function_call(
-                pgrx::pg_sys::timetz_part,
-                &["timezone".into_datum(), timetz.into_datum()],
-            )
-        }
-        .expect("cannot extract timezone from timetz");
-
-        timezone_as_secs
-    }
-
-    #[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
-    {
-        let timezone_as_secs: AnyNumeric = unsafe {
-            direct_function_call(
-                pgrx::pg_sys::extract_timetz,
-                &["timezone".into_datum(), timetz.into_datum()],
-            )
-        }
-        .expect("cannot extract timezone from timetz");
-
-        let timezone_as_secs: f64 = timezone_as_secs
-            .try_into()
-            .unwrap_or_else(|e| panic!("{}", e));
-
-        timezone_as_secs
-    }
-}
-
 #[allow(non_snake_case)]
 pub(crate) fn MarkGUCPrefixReserved(guc_prefix: &str) {
-    #[cfg(any(feature = "pg13", feature = "pg14"))]
+    #[cfg(feature = "pg14")]
     unsafe {
         pgrx::pg_sys::EmitWarningsOnPlaceholders(guc_prefix.as_pg_cstr())
     }

--- a/src/type_compat/pg_arrow_type_conversions.rs
+++ b/src/type_compat/pg_arrow_type_conversions.rs
@@ -5,8 +5,6 @@ use pgrx::{
     direct_function_call, pg_sys, AnyNumeric, IntoDatum,
 };
 
-use crate::parquet_copy_hook::pg_compat::extract_timezone_from_timetz;
-
 pub(crate) const MAX_DECIMAL_PRECISION: usize = 38;
 
 pub(crate) fn date_to_i32(date: Date) -> i32 {
@@ -130,7 +128,17 @@ pub(crate) fn i64_to_time(i64_time: i64) -> Time {
 }
 
 pub(crate) fn timetz_to_i64(timetz: TimeWithTimeZone) -> i64 {
-    let timezone_as_secs = extract_timezone_from_timetz(timetz);
+    let timezone_as_secs: AnyNumeric = unsafe {
+        direct_function_call(
+            pg_sys::extract_timetz,
+            &["timezone".into_datum(), timetz.into_datum()],
+        )
+    }
+    .expect("cannot extract timezone from timetz");
+
+    let timezone_as_secs: f64 = timezone_as_secs
+        .try_into()
+        .unwrap_or_else(|e| panic!("{}", e));
 
     let timezone_as_interval = Interval::from_seconds(timezone_as_secs);
     let adjusted_timetz: TimeWithTimeZone = unsafe {


### PR DESCRIPTION
3 functions need to be ported to support PG{14,15}.

`pg_analyze_and_rewrite` for pg14
`pg_analyze_and_rewrite_fixedparams` for >=pg15

`Value` for pg14
`String` for >= pg15

`EmitWarningsOnPlaceholders` for pg14
`MarkGUCPrefixReserved` for >= pg15