### PR TITLE
fix: Use tabs not spaces for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,23 +5,23 @@ PG_CONFIG ?= pg_config
 all: pg_parquet
 
 cargo-exists:
-       @which cargo > /dev/null || (echo "cargo is not available. Please install cargo." && exit 1)
+	   @which cargo > /dev/null || (echo "cargo is not available. Please install cargo." && exit 1)
 
 cargo-pgrx-exists: cargo-exists
-       @which cargo-pgrx > /dev/null || (echo "cargo-pgrx is not available. Please install cargo-pgrx." && exit 1)
+	   @which cargo-pgrx > /dev/null || (echo "cargo-pgrx is not available. Please install cargo-pgrx." && exit 1)
 
 pg_parquet: cargo-pgrx-exists
-       cargo build --release --features pg17
+	   cargo build --release --features pg17
 
 install: pg_parquet
-       cargo pgrx install --release --features pg17
+	   cargo pgrx install --release --features pg17
 
 clean: cargo-exists
-       cargo clean
+	   cargo clean
 
 check: cargo-pgrx-exists
-       RUST_TEST_THREADS=1 cargo pgrx test pg17
+	   RUST_TEST_THREADS=1 cargo pgrx test pg17
 
 uninstall:
-       rm -f $(shell $(PG_CONFIG) --pkglibdir)/pg_parquet.so
-       rm -f $(shell $(PG_CONFIG) --sharedir)/extension/pg_parquet*
+	   rm -f $(shell $(PG_CONFIG) --pkglibdir)/pg_parquet.so
+	   rm -f $(shell $(PG_CONFIG) --sharedir)/extension/pg_parquet*


### PR DESCRIPTION
`Makefile` requires tabs not spaces; this fixes that.
