### PR TITLE
Numeric improvement and fix

### DIFF
--- a/src/arrow_parquet/arrow_to_pg/numeric.rs
+++ b/src/arrow_parquet/arrow_to_pg/numeric.rs
@@ -11,8 +11,15 @@ impl ArrowArrayToPgType<AnyNumeric> for Decimal128Array {
         if self.is_null(0) {
             None
         } else {
+            let precision = context.precision.expect("Expected precision");
             let scale = context.scale.expect("Expected scale");
-            Some(i128_to_numeric(self.value(0), scale))
+
+            Some(i128_to_numeric(
+                self.value(0),
+                precision,
+                scale,
+                context.typmod,
+            ))
         }
     }
 }
@@ -20,10 +27,12 @@ impl ArrowArrayToPgType<AnyNumeric> for Decimal128Array {
 // Numeric[]
 impl ArrowArrayToPgType<Vec<Option<AnyNumeric>>> for Decimal128Array {
     fn to_pg_type(self, context: &ArrowToPgAttributeContext) -> Option<Vec<Option<AnyNumeric>>> {
+        let precision = context.precision.expect("Expected precision");
         let scale = context.scale.expect("Expected scale");
+
         let mut vals = vec![];
         for val in self.iter() {
-            let val = val.map(|v| i128_to_numeric(v, scale));
+            let val = val.map(|v| i128_to_numeric(v, precision, scale, context.typmod));
             vals.push(val);
         }
         Some(vals)

--- a/src/arrow_parquet/pg_to_arrow/numeric.rs
+++ b/src/arrow_parquet/pg_to_arrow/numeric.rs
@@ -22,7 +22,10 @@ impl PgTypeToArrowArray<AnyNumeric> for Vec<Option<AnyNumeric>> {
 
         let numerics = self
             .into_iter()
-            .map(|numeric| numeric.map(numeric_to_i128))
+            .map(|numeric| {
+                numeric
+                    .map(|numeric| numeric_to_i128(numeric, context.typmod, context.field.name()))
+            })
             .collect::<Vec<_>>();
 
         let numeric_array = Decimal128Array::from(numerics)
@@ -43,7 +46,10 @@ impl PgTypeToArrowArray<AnyNumeric> for Vec<Option<Vec<Option<AnyNumeric>>>> {
             .into_iter()
             .flatten()
             .flatten()
-            .map(|numeric| numeric.map(numeric_to_i128))
+            .map(|numeric| {
+                numeric
+                    .map(|numeric| numeric_to_i128(numeric, context.typmod, context.field.name()))
+            })
             .collect::<Vec<_>>();
 
         let precision = context


### PR DESCRIPTION
**Problem**
Previously, we were writing unbounded numerics, that does not specify precision and scale (i.e. `numeric`), as text since they can be too large to represent as parquet decimal. Most of the time users ignores the precision for numeric columns, so they were written as text. That prevents pushing down some operators on the numeric type by execution engines.

**Improvement**
We start to read/write unbounded numerics as `numeric(38, 16)` to parquet file. We throw a runtime error if an unbounded numeric value exceeds `22 digits` before the decimal point or `16 digits` after the decimal point.

For the users that bump into the error, we give hint to change the column type to a numeric(p,s) with precision and scale specified, to get rid of the error.

**Fixes**
Arrow to pg conversions were not correct for some cases
- when there is no decimal point e.g. 1234 (fixed by relying on pg compatible `Decimal128Type::format_decimal` by arrow)
- when the scale is negative e.g. numeric(5,-2) (arrow does not allow negative scale, fixed by adding `abs(scale)` to `precision` and setting the `scale` to 0, which means `numeric(5,-2) => numeric(7,0)` at parquet file. copy from can convert it back to numeric(5,-2))

These cases are fixed and covered by tests.