### PR TITLE
WIP: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM postgres:17
+
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl build-essential openssl libssl-dev pkg-config
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+ENV PATH="$PATH:/root/.cargo/bin/"
+RUN cargo install cargo-pgrx
+RUN cargo pgrx init --pg17 $(which pg_config)
+# RUN echo "shared_preload_libraries = 'pg_parquet'" >> ~/.pgrx/data-17/postgresql.conf
+RUN echo "shared_preload_libraries = 'pg_parquet'" >> ~/.pgrx/postgresql.conf
+COPY . /root/.pgrx/src
+RUN cd /root/.pgrx/src && cargo pgrx run


### PR DESCRIPTION
I am interested in using this to export a bunch of Pg tables in parquet format without creating/tainting a local Pg install with this.

So Docker to the rescue, but since I am totally out of my depth here I have no idea how to resolve where it fails on my Mac with

```
 > [8/8] RUN cd /root/.pgrx/src && cargo pgrx run:                                                                                                              
6.338 Error:                                                                                                                                                    
6.338    0: Postgres `17.2-1.pgdg120+1` is not managed by pgrx 
```