### PR TITLE
Fix destreceiver api

### DIFF
--- a/src/parquet_copy_hook/copy_to.rs
+++ b/src/parquet_copy_hook/copy_to.rs
@@ -31,7 +31,7 @@ pub(crate) fn execute_copy_to_with_dest_receiver(
     query_string: &CStr,
     params: &PgBox<ParamListInfoData>,
     query_env: &PgBox<QueryEnvironment>,
-    parquet_dest: PgBox<DestReceiver>,
+    parquet_dest: &PgBox<DestReceiver>,
 ) -> u64 {
     unsafe {
         debug_assert!(is_a(p_stmt.utilityStmt, T_CopyStmt));


### PR DESCRIPTION
- [x] We need to put `*mut ParquetWriterContext` into `PgParquetDestReciever`. As it is opaque type to C users, it is safe to do and way safer than static context which causes headache when 2 concurrent dest receiver is running.
- [x] PgParquetDestReceiver should not own and drop tupledesc that is received via its startup callback. That is unexpected for the caller.
- [x] We should not filter our dropped columns of the given tupledesc at startup callback since it cause "tupledesc does not match tuple" errors.  