### PR TITLE
Cache object stores per scheme + bucket per session

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -4,5 +4,6 @@ trap "echo 'Caught termination signal. Exiting...'; exit 0" SIGINT SIGTERM
 
 # create azurite container
 az storage container create -n $AZURE_TEST_CONTAINER_NAME --connection-string $AZURE_STORAGE_CONNECTION_STRING
+az storage container create -n ${AZURE_TEST_CONTAINER_NAME}2 --connection-string $AZURE_STORAGE_CONNECTION_STRING
 
 sleep infinity

--- a/.devcontainer/minio-entrypoint.sh
+++ b/.devcontainer/minio-entrypoint.sh
@@ -14,7 +14,8 @@ done
 # set access key and secret key
 mc alias set local $AWS_ENDPOINT_URL $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
 
-# create bucket
+# create buckets
 mc mb local/$AWS_S3_TEST_BUCKET
+mc mb local/${AWS_S3_TEST_BUCKET}2
 
 wait $minio_pid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
 
           # create container
           az storage container create -n $AZURE_TEST_CONTAINER_NAME --connection-string $AZURE_STORAGE_CONNECTION_STRING
+          az storage container create -n ${AZURE_TEST_CONTAINER_NAME}2 --connection-string $AZURE_STORAGE_CONNECTION_STRING
 
       - name: Run tests
         run: |

--- a/src/arrow_parquet/uri_utils.rs
+++ b/src/arrow_parquet/uri_utils.rs
@@ -18,8 +18,8 @@ use pgrx::{
 use url::Url;
 
 use crate::{
-    arrow_parquet::parquet_writer::DEFAULT_ROW_GROUP_SIZE, object_store::create_object_store,
-    PG_BACKEND_TOKIO_RUNTIME,
+    arrow_parquet::parquet_writer::DEFAULT_ROW_GROUP_SIZE,
+    object_store::object_store_cache::get_or_create_object_store, PG_BACKEND_TOKIO_RUNTIME,
 };
 
 const PARQUET_OBJECT_STORE_READ_ROLE: &str = "parquet_object_store_read";
@@ -58,7 +58,7 @@ pub(crate) fn parquet_schema_from_uri(uri: &Url) -> SchemaDescriptor {
 
 pub(crate) fn parquet_metadata_from_uri(uri: &Url) -> Arc<ParquetMetaData> {
     let copy_from = true;
-    let (parquet_object_store, location) = create_object_store(uri, copy_from);
+    let (parquet_object_store, location) = get_or_create_object_store(uri, copy_from);
 
     PG_BACKEND_TOKIO_RUNTIME.block_on(async {
         let object_store_meta = parquet_object_store
@@ -81,7 +81,7 @@ pub(crate) fn parquet_metadata_from_uri(uri: &Url) -> Arc<ParquetMetaData> {
 
 pub(crate) fn parquet_reader_from_uri(uri: &Url) -> ParquetRecordBatchStream<ParquetObjectReader> {
     let copy_from = true;
-    let (parquet_object_store, location) = create_object_store(uri, copy_from);
+    let (parquet_object_store, location) = get_or_create_object_store(uri, copy_from);
 
     PG_BACKEND_TOKIO_RUNTIME.block_on(async {
         let object_store_meta = parquet_object_store
@@ -113,7 +113,7 @@ pub(crate) fn parquet_writer_from_uri(
     writer_props: WriterProperties,
 ) -> AsyncArrowWriter<ParquetObjectWriter> {
     let copy_from = false;
-    let (parquet_object_store, location) = create_object_store(uri, copy_from);
+    let (parquet_object_store, location) = get_or_create_object_store(uri, copy_from);
 
     let parquet_object_writer = ParquetObjectWriter::new(parquet_object_store, location);
 

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -1,8 +1,3 @@
-use std::sync::Arc;
-
-use object_store::{path::Path, ObjectStore, ObjectStoreScheme};
-use url::Url;
-
 use crate::{
     arrow_parquet::uri_utils::uri_as_string,
     object_store::{
@@ -15,42 +10,4 @@ use crate::{
 pub(crate) mod aws;
 pub(crate) mod azure;
 pub(crate) mod local_file;
-
-pub(crate) fn create_object_store(uri: &Url, copy_from: bool) -> (Arc<dyn ObjectStore>, Path) {
-    let (scheme, path) = ObjectStoreScheme::parse(uri).unwrap_or_else(|_| {
-        panic!(
-            "unrecognized uri {}. pg_parquet supports local paths, s3:// or azure:// schemes.",
-            uri
-        )
-    });
-
-    // object_store crate can recognize a bunch of different schemes and paths, but we only support
-    // local, azure, and s3 schemes with a subset of all supported paths.
-    match scheme {
-        ObjectStoreScheme::AmazonS3 => {
-            let storage_container = Arc::new(create_s3_object_store(uri));
-
-            (storage_container, path)
-        }
-        ObjectStoreScheme::MicrosoftAzure => {
-            let storage_container = Arc::new(create_azure_object_store(uri));
-
-            (storage_container, path)
-        }
-        ObjectStoreScheme::Local => {
-            let storage_container = Arc::new(create_local_file_object_store(uri, copy_from));
-
-            let path =
-                Path::from_filesystem_path(uri_as_string(uri)).unwrap_or_else(|e| panic!("{}", e));
-
-            (storage_container, path)
-        }
-        _ => {
-            panic!(
-                "unsupported scheme {} in uri {}. pg_parquet supports local paths, s3:// or azure:// schemes.",
-                uri.scheme(),
-                uri
-            );
-        }
-    }
-}
+pub(crate) mod object_store_cache;

--- a/src/object_store/local_file.rs
+++ b/src/object_store/local_file.rs
@@ -1,10 +1,15 @@
+use std::sync::Arc;
+
 use object_store::local::LocalFileSystem;
 use url::Url;
 
-use super::uri_as_string;
+use super::{object_store_cache::ObjectStoreWithExpiration, uri_as_string};
 
 // create_local_file_object_store creates a LocalFileSystem object store with the given path.
-pub(crate) fn create_local_file_object_store(uri: &Url, copy_from: bool) -> LocalFileSystem {
+pub(crate) fn create_local_file_object_store(
+    uri: &Url,
+    copy_from: bool,
+) -> ObjectStoreWithExpiration {
     let path = uri_as_string(uri);
 
     if !copy_from {
@@ -17,5 +22,11 @@ pub(crate) fn create_local_file_object_store(uri: &Url, copy_from: bool) -> Loca
             .unwrap_or_else(|e| panic!("{}", e));
     }
 
-    LocalFileSystem::new()
+    let object_store = LocalFileSystem::new();
+    let expire_at = None;
+
+    ObjectStoreWithExpiration {
+        object_store: Arc::new(object_store),
+        expire_at,
+    }
 }

--- a/src/object_store/object_store_cache.rs
+++ b/src/object_store/object_store_cache.rs
@@ -103,17 +103,10 @@ impl ObjectStoreWithExpiration {
             let expired = expire_at < SystemTime::now();
 
             if expired {
-                let expiration_warn_msg =
-                    format!("credentials for {bucket} expired at {expire_at:?}");
-
-                let expiration_hint = "New credentials will be automatically retrieved if configured.\n\
-                                       Otherwise, please create a new postgres session to refresh the credentials.";
-
                 ereport!(
-                    PgLogLevel::WARNING,
+                    PgLogLevel::DEBUG2,
                     PgSqlErrorCode::ERRCODE_WARNING,
-                    expiration_warn_msg,
-                    expiration_hint,
+                    format!("credentials for {bucket} expired at {expire_at:?}"),
                 );
             }
 

--- a/src/object_store/object_store_cache.rs
+++ b/src/object_store/object_store_cache.rs
@@ -1,0 +1,214 @@
+use std::{
+    collections::HashMap,
+    hash::{Hash, Hasher},
+    sync::Arc,
+    time::SystemTime,
+};
+
+use object_store::{path::Path, ObjectStore, ObjectStoreScheme};
+use once_cell::sync::Lazy;
+use pgrx::{ereport, PgLogLevel, PgSqlErrorCode};
+use url::Url;
+
+use super::{
+    aws::parse_s3_bucket, azure::parse_azure_blob_container, create_azure_object_store,
+    create_local_file_object_store, create_s3_object_store,
+};
+
+// OBJECT_STORE_CACHE is a global cache for object stores per Postgres session.
+// It caches object stores based on the scheme and bucket.
+// Local paths are not cached.
+static mut OBJECT_STORE_CACHE: Lazy<ObjectStoreCache> = Lazy::new(ObjectStoreCache::new);
+
+pub(crate) fn get_or_create_object_store(
+    uri: &Url,
+    copy_from: bool,
+) -> (Arc<dyn ObjectStore>, Path) {
+    #[allow(static_mut_refs)]
+    unsafe {
+        OBJECT_STORE_CACHE.get_or_create(uri, copy_from)
+    }
+}
+
+struct ObjectStoreCache {
+    cache: HashMap<ObjectStoreCacheKey, ObjectStoreWithExpiration>,
+}
+
+impl ObjectStoreCache {
+    fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+        }
+    }
+
+    fn get_or_create(&mut self, uri: &Url, copy_from: bool) -> (Arc<dyn ObjectStore>, Path) {
+        let (scheme, path) = ObjectStoreScheme::parse(uri).unwrap_or_else(|_| {
+            panic!(
+                "unrecognized uri {}. pg_parquet supports local paths, s3:// or azure:// schemes.",
+                uri
+            )
+        });
+
+        // no need to cache for local files
+        if scheme == ObjectStoreScheme::Local {
+            let item = Self::create(scheme, uri, copy_from);
+            return (item.object_store, path);
+        }
+
+        let key = ObjectStoreCacheKey::from_uri(uri, scheme.clone());
+
+        if let Some(item) = self.cache.get(&key) {
+            if item.expired(&key.bucket) {
+                self.cache.remove(&key);
+            } else {
+                return (item.object_store.clone(), path);
+            }
+        }
+
+        let item = Self::create(scheme, uri, copy_from);
+
+        self.cache.insert(key, item.clone());
+
+        (item.object_store.clone(), path)
+    }
+
+    fn create(scheme: ObjectStoreScheme, uri: &Url, copy_from: bool) -> ObjectStoreWithExpiration {
+        // object_store crate can recognize a bunch of different schemes and paths, but we only support
+        // local, azure, and s3 schemes with a subset of all supported paths.
+        match scheme {
+            ObjectStoreScheme::AmazonS3 => create_s3_object_store(uri),
+            ObjectStoreScheme::MicrosoftAzure => create_azure_object_store(uri),
+            ObjectStoreScheme::Local => create_local_file_object_store(uri, copy_from),
+            _ => panic!(
+                    "unsupported scheme {} in uri {}. pg_parquet supports local paths, s3:// or azure:// schemes.",
+                    uri.scheme(),
+                    uri
+                ),
+        }
+    }
+}
+
+// ObjectStoreWithExpiration is a value for the object store cache map.
+#[derive(Clone)]
+pub(crate) struct ObjectStoreWithExpiration {
+    pub(crate) object_store: Arc<dyn object_store::ObjectStore>,
+
+    // expiration time (if not applicable, the object_store will never expire)
+    pub(crate) expire_at: Option<SystemTime>,
+}
+
+impl ObjectStoreWithExpiration {
+    fn expired(&self, bucket: &str) -> bool {
+        if let Some(expire_at) = self.expire_at {
+            let expired = expire_at < SystemTime::now();
+
+            if expired {
+                let expiration_warn_msg =
+                    format!("credentials for {bucket} expired at {expire_at:?}");
+
+                let expiration_hint = "New credentials will be automatically retrieved if configured.\n\
+                                       Otherwise, please create a new postgres session to refresh the credentials.";
+
+                ereport!(
+                    PgLogLevel::WARNING,
+                    PgSqlErrorCode::ERRCODE_WARNING,
+                    expiration_warn_msg,
+                    expiration_hint,
+                );
+            }
+
+            expired
+        } else {
+            false
+        }
+    }
+}
+
+// ObjectStoreCacheKey is a key for the object store cache map
+// We cache object stores based on the scheme and bucket.
+// i.e. 1 object store per scheme and bucket.
+#[derive(Clone, Eq, PartialEq)]
+struct ObjectStoreCacheKey {
+    scheme: ObjectStoreScheme,
+    bucket: String,
+}
+
+impl ObjectStoreCacheKey {
+    fn from_uri(uri: &Url, scheme: ObjectStoreScheme) -> Self {
+        let bucket = match scheme {
+            ObjectStoreScheme::AmazonS3 => parse_s3_bucket(uri).unwrap_or_else(|| panic!("unsupported s3 uri: {uri}")),
+            ObjectStoreScheme::MicrosoftAzure => parse_azure_blob_container(uri).unwrap_or_else(|| panic!("unsupported azure blob storage uri: {uri}")),
+            ObjectStoreScheme::Local => panic!("local paths should not be cached"),
+            _ => panic!(
+                "unsupported scheme {} in uri {}. pg_parquet supports local paths, s3:// or azure:// schemes.",
+                uri.scheme(),
+                uri
+            ),
+        };
+
+        ObjectStoreCacheKey { scheme, bucket }
+    }
+}
+
+impl Hash for ObjectStoreCacheKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let schema_tag = self.scheme.clone() as i32;
+        schema_tag.hash(state);
+        self.bucket.hash(state);
+    }
+}
+
+// The following udfs are only used for testing purposes.
+#[cfg(feature = "pg_test")]
+#[pgrx::pg_schema]
+mod parquet_test {
+    use std::time::UNIX_EPOCH;
+
+    use pgrx::{iter::TableIterator, name, pg_extern, pg_sys::Timestamp};
+
+    use super::OBJECT_STORE_CACHE;
+
+    #[pg_extern]
+    fn object_store_cache_clear() {
+        #[allow(static_mut_refs)]
+        unsafe {
+            OBJECT_STORE_CACHE.cache.clear();
+        }
+    }
+
+    #[pg_extern]
+    fn object_store_cache_expire_bucket(bucket: &str) {
+        #[allow(static_mut_refs)]
+        let cache = unsafe { &mut super::OBJECT_STORE_CACHE.cache };
+
+        cache.retain(|key, _| key.bucket != bucket);
+    }
+
+    #[pg_extern]
+    fn object_store_cache_items() -> TableIterator<
+        'static,
+        (
+            name!(scheme, String),
+            name!(bucket, String),
+            name!(expire_at, Option<Timestamp>),
+        ),
+    > {
+        #[allow(static_mut_refs)]
+        let cache = unsafe { &super::OBJECT_STORE_CACHE.cache };
+
+        let rows = cache
+            .iter()
+            .map(|(key, value)| {
+                let scheme = format!("{:?}", key.scheme);
+                let bucket = key.bucket.clone();
+                let expire_at = value
+                    .expire_at
+                    .map(|t| t.duration_since(UNIX_EPOCH).unwrap().as_micros() as Timestamp);
+
+                (scheme, bucket, expire_at)
+            })
+            .collect::<Vec<_>>();
+
+        TableIterator::new(rows)
+    }
+}


### PR DESCRIPTION
In this PR, we cache object stores per scheme (e.g. s3) + bucket (or container) combination in each Postgres session. This will reduce authentication costs by only doing it at the first time.

For s3, object_store does not perform sts assume_role to get temp token, so pg_parquet make use of aws sdk to perform it. And then configure object_store with the temp token that it fetched. pg_parquet also checks expiration of the aws tokens and fetch the temp token if it expires. (obviously if you configured temp token auth via config)

Closes #93