### PR TITLE
Support file_size_bytes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,9 @@ Supported authorization methods' priority order is shown below:
 ## Copy Options
 `pg_parquet` supports the following options in the `COPY TO` command:
 - `format parquet`: you need to specify this option to read or write Parquet files which does not end with `.parquet[.<compression>]` extension,
-- `file_size_bytes <int>`: the total byte size per Parquet file. When set, the parquet files, with target size, are created under parent directory (named the same as file name without file extension). By default, when not specified, a single file is generated without creating a parent folder.
-- `row_group_size <int>`: the number of rows in each row group while writing Parquet files. The default row group size is `122880`,
-- `row_group_size_bytes <int>`: the total byte size of rows in each row group while writing Parquet files. The default row group size bytes is `row_group_size * 1024`,
+- `file_size_bytes <string>`: the total file size per Parquet file. When set, the parquet files, with target size, are created under parent directory (named the same as file name). By default, when not specified, a single file is generated without creating a parent folder. You can specify total bytes without unit like `file_size_bytes 2000000` or with unit (KB, MB, or GB) like `file_size_bytes '1MB'`,
+- `row_group_size <int64>`: the number of rows in each row group while writing Parquet files. The default row group size is `122880`,
+- `row_group_size_bytes <int64>`: the total byte size of rows in each row group while writing Parquet files. The default row group size bytes is `row_group_size * 1024`,
 - `compression <string>`: the compression format to use while writing Parquet files. The supported compression formats are `uncompressed`, `snappy`, `gzip`, `brotli`, `lz4`, `lz4raw` and `zstd`. The default compression format is `snappy`. If not specified, the compression format is determined by the file extension,
 - `compression_level <int>`: the compression level to use while writing Parquet files. The supported compression levels are only supported for `gzip`, `zstd` and `brotli` compression formats. The default compression level is `6` for `gzip (0-10)`, `1` for `zstd (1-22)` and `1` for `brotli (0-11)`.
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Supported authorization methods' priority order is shown below:
 ## Copy Options
 `pg_parquet` supports the following options in the `COPY TO` command:
 - `format parquet`: you need to specify this option to read or write Parquet files which does not end with `.parquet[.<compression>]` extension,
+- `file_size_bytes <int>`: the total byte size per Parquet file. When set, the parquet files, with target size, are created under parent directory (named the same as file name without file extension). By default, when not specified, a single file is generated without creating a parent folder.
 - `row_group_size <int>`: the number of rows in each row group while writing Parquet files. The default row group size is `122880`,
 - `row_group_size_bytes <int>`: the total byte size of rows in each row group while writing Parquet files. The default row group size bytes is `row_group_size * 1024`,
 - `compression <string>`: the compression format to use while writing Parquet files. The supported compression formats are `uncompressed`, `snappy`, `gzip`, `brotli`, `lz4`, `lz4raw` and `zstd`. The default compression format is `snappy`. If not specified, the compression format is determined by the file extension,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod type_compat;
 #[allow(unused_imports)]
 pub use crate::arrow_parquet::compression::PgParquetCompression;
 #[allow(unused_imports)]
-pub use crate::parquet_copy_hook::copy_to_dest_receiver::create_copy_to_parquet_dest_receiver;
+pub use crate::parquet_copy_hook::copy_to_split_dest_receiver::create_copy_to_parquet_split_dest_receiver;
 
 pgrx::pg_module_magic!();
 

--- a/src/object_store/local_file.rs
+++ b/src/object_store/local_file.rs
@@ -13,6 +13,13 @@ pub(crate) fn create_local_file_object_store(
     let path = uri_as_string(uri);
 
     if !copy_from {
+        // create parent folder if it doesn't exist
+        let parent = std::path::Path::new(&path)
+            .parent()
+            .unwrap_or_else(|| panic!("invalid parent for path: {}", path));
+
+        std::fs::create_dir_all(parent).unwrap_or_else(|e| panic!("{}", e));
+
         // create or overwrite the local file
         std::fs::OpenOptions::new()
             .write(true)

--- a/src/parquet_copy_hook.rs
+++ b/src/parquet_copy_hook.rs
@@ -1,6 +1,7 @@
 pub(crate) mod copy_from;
 pub(crate) mod copy_to;
 pub(crate) mod copy_to_dest_receiver;
+pub(crate) mod copy_to_split_dest_receiver;
 pub(crate) mod copy_utils;
 pub(crate) mod hook;
 pub(crate) mod pg_compat;

--- a/src/parquet_copy_hook/copy_to_dest_receiver.rs
+++ b/src/parquet_copy_hook/copy_to_dest_receiver.rs
@@ -167,12 +167,9 @@ pub(crate) extern "C" fn copy_startup(
     };
     parquet_dest.natts = tupledesc.len();
 
-    parquet_dest.target_batch_size = if parquet_dest.copy_options.row_group_size < RECORD_BATCH_SIZE
-    {
-        parquet_dest.copy_options.row_group_size
-    } else {
-        RECORD_BATCH_SIZE
-    };
+    // handle when row group size is set less than RECORD_BATCH_SIZE
+    parquet_dest.target_batch_size =
+        std::cmp::min(parquet_dest.copy_options.row_group_size, RECORD_BATCH_SIZE);
 
     let uri = unsafe { CStr::from_ptr(parquet_dest.uri) }
         .to_str()

--- a/src/parquet_copy_hook/copy_to_dest_receiver.rs
+++ b/src/parquet_copy_hook/copy_to_dest_receiver.rs
@@ -10,21 +10,14 @@ use pg_sys::{
 use pgrx::{prelude::*, FromDatum, PgList, PgMemoryContexts, PgTupleDesc};
 
 use crate::arrow_parquet::{
-    compression::{PgParquetCompression, INVALID_COMPRESSION_LEVEL},
-    parquet_writer::{ParquetWriterContext, DEFAULT_ROW_GROUP_SIZE, DEFAULT_ROW_GROUP_SIZE_BYTES},
-    uri_utils::ParsedUriInfo,
+    parquet_writer::ParquetWriterContext,
+    uri_utils::{ParsedUriInfo, RECORD_BATCH_SIZE},
 };
 
-#[repr(C)]
-struct CopyToParquetOptions {
-    pub row_group_size: i64,
-    pub row_group_size_bytes: i64,
-    pub compression: PgParquetCompression,
-    pub compression_level: i32,
-}
+use super::copy_to_split_dest_receiver::CopyToParquetOptions;
 
 #[repr(C)]
-struct CopyToParquetDestReceiver {
+pub(crate) struct CopyToParquetDestReceiver {
     dest: DestReceiver,
     natts: usize,
     tupledesc: TupleDesc,
@@ -32,6 +25,7 @@ struct CopyToParquetDestReceiver {
     collected_tuple_count: i64,
     collected_tuple_size: i64,
     collected_tuple_column_sizes: *mut i64,
+    target_batch_size: i64,
     uri: *const c_char,
     copy_options: CopyToParquetOptions,
     per_copy_context: MemoryContext,
@@ -74,14 +68,6 @@ impl CopyToParquetDestReceiver {
         };
     }
 
-    fn collected_tuples_exceeds_row_group_size(&self) -> bool {
-        self.collected_tuple_count >= self.copy_options.row_group_size
-    }
-
-    fn collected_tuples_exceeds_row_group_size_bytes(&self) -> bool {
-        self.collected_tuple_size >= self.copy_options.row_group_size_bytes
-    }
-
     fn collected_tuples_exceeds_max_col_size(&self, tuple_column_sizes: &[i32]) -> bool {
         const MAX_ARROW_ARRAY_SIZE: i64 = i32::MAX as _;
 
@@ -93,6 +79,16 @@ impl CopyToParquetDestReceiver {
             .zip(tuple_column_sizes)
             .map(|(a, b)| *a + *b as i64)
             .any(|size| size > MAX_ARROW_ARRAY_SIZE)
+    }
+
+    pub(crate) fn collected_bytes(&self) -> usize {
+        let current_parquet_writer_context = unsafe {
+            self.parquet_writer_context
+                .as_ref()
+                .expect("parquet writer context is not found")
+        };
+
+        current_parquet_writer_context.bytes_written()
     }
 
     fn write_tuples_to_parquet(&mut self) {
@@ -118,7 +114,7 @@ impl CopyToParquetDestReceiver {
                 .as_mut()
                 .expect("parquet writer context is not found")
         };
-        current_parquet_writer_context.write_new_row_group(tuples);
+        current_parquet_writer_context.write_tuples(tuples);
 
         self.reset_collected_tuples();
     }
@@ -143,7 +139,11 @@ impl CopyToParquetDestReceiver {
 }
 
 #[pg_guard]
-extern "C" fn copy_startup(dest: *mut DestReceiver, _operation: i32, tupledesc: TupleDesc) {
+pub(crate) extern "C" fn copy_startup(
+    dest: *mut DestReceiver,
+    _operation: i32,
+    tupledesc: TupleDesc,
+) {
     let parquet_dest = unsafe {
         (dest as *mut CopyToParquetDestReceiver)
             .as_mut()
@@ -167,6 +167,13 @@ extern "C" fn copy_startup(dest: *mut DestReceiver, _operation: i32, tupledesc: 
     };
     parquet_dest.natts = tupledesc.len();
 
+    parquet_dest.target_batch_size = if parquet_dest.copy_options.row_group_size < RECORD_BATCH_SIZE
+    {
+        parquet_dest.copy_options.row_group_size
+    } else {
+        RECORD_BATCH_SIZE
+    };
+
     let uri = unsafe { CStr::from_ptr(parquet_dest.uri) }
         .to_str()
         .expect("uri is not a valid C string");
@@ -175,18 +182,14 @@ extern "C" fn copy_startup(dest: *mut DestReceiver, _operation: i32, tupledesc: 
         panic!("{}", e.to_string());
     });
 
-    let compression = parquet_dest.copy_options.compression;
-
-    let compression_level = parquet_dest.copy_options.compression_level;
-
     // leak the parquet writer context since it will be used during the COPY operation
     let parquet_writer_context =
-        ParquetWriterContext::new(uri_info, compression, compression_level, &tupledesc);
+        ParquetWriterContext::new(uri_info, parquet_dest.copy_options, &tupledesc);
     parquet_dest.parquet_writer_context = Box::into_raw(Box::new(parquet_writer_context));
 }
 
 #[pg_guard]
-extern "C" fn copy_receive(slot: *mut TupleTableSlot, dest: *mut DestReceiver) -> bool {
+pub(crate) extern "C" fn copy_receive(slot: *mut TupleTableSlot, dest: *mut DestReceiver) -> bool {
     let parquet_dest = unsafe {
         (dest as *mut CopyToParquetDestReceiver)
             .as_mut()
@@ -216,6 +219,9 @@ extern "C" fn copy_receive(slot: *mut TupleTableSlot, dest: *mut DestReceiver) -
 
             let column_sizes = tuple_column_sizes(&datums, &tupledesc);
 
+            // we use arrow arrays as intermediate format when writing to parquet.
+            // To not hit into arrow array size limit, write the tuples before
+            // collecting new one into the batch.
             if parquet_dest.collected_tuples_exceeds_max_col_size(&column_sizes) {
                 parquet_dest.write_tuples_to_parquet();
             }
@@ -225,9 +231,7 @@ extern "C" fn copy_receive(slot: *mut TupleTableSlot, dest: *mut DestReceiver) -
 
             parquet_dest.collect_tuple(heap_tuple, column_sizes);
 
-            if parquet_dest.collected_tuples_exceeds_row_group_size()
-                || parquet_dest.collected_tuples_exceeds_row_group_size_bytes()
-            {
+            if parquet_dest.collected_tuple_count == parquet_dest.target_batch_size {
                 parquet_dest.write_tuples_to_parquet();
             }
         });
@@ -237,7 +241,7 @@ extern "C" fn copy_receive(slot: *mut TupleTableSlot, dest: *mut DestReceiver) -
 }
 
 #[pg_guard]
-extern "C" fn copy_shutdown(dest: *mut DestReceiver) {
+pub(crate) extern "C" fn copy_shutdown(dest: *mut DestReceiver) {
     let parquet_dest = unsafe {
         (dest as *mut CopyToParquetDestReceiver)
             .as_mut()
@@ -252,79 +256,7 @@ extern "C" fn copy_shutdown(dest: *mut DestReceiver) {
 }
 
 #[pg_guard]
-extern "C" fn copy_destroy(_dest: *mut DestReceiver) {}
-
-// create_copy_to_parquet_dest_receiver creates a new CopyToParquetDestReceiver that can be
-// used as a destination receiver for COPY TO command. All arguments, except "uri", are optional
-// and have default values if not provided.
-#[pg_guard]
-#[no_mangle]
-pub extern "C" fn create_copy_to_parquet_dest_receiver(
-    uri: *const c_char,
-    row_group_size: *const i64,
-    row_group_size_bytes: *const i64,
-    compression: *const PgParquetCompression,
-    compression_level: *const i32,
-) -> *mut DestReceiver {
-    let per_copy_context = unsafe {
-        AllocSetContextCreateExtended(
-            CurrentMemoryContext as _,
-            "ParquetCopyDestReceiver".as_pg_cstr(),
-            ALLOCSET_DEFAULT_MINSIZE as _,
-            ALLOCSET_DEFAULT_INITSIZE as _,
-            ALLOCSET_DEFAULT_MAXSIZE as _,
-        )
-    };
-
-    let row_group_size = if row_group_size.is_null() {
-        DEFAULT_ROW_GROUP_SIZE
-    } else {
-        unsafe { *row_group_size }
-    };
-
-    let row_group_size_bytes = if row_group_size_bytes.is_null() {
-        DEFAULT_ROW_GROUP_SIZE_BYTES
-    } else {
-        unsafe { *row_group_size_bytes }
-    };
-
-    let compression = if compression.is_null() {
-        PgParquetCompression::default()
-    } else {
-        unsafe { *compression }
-    };
-
-    let compression_level = if compression_level.is_null() {
-        compression
-            .default_compression_level()
-            .unwrap_or(INVALID_COMPRESSION_LEVEL)
-    } else {
-        unsafe { *compression_level }
-    };
-
-    let mut parquet_dest =
-        unsafe { PgBox::<CopyToParquetDestReceiver, AllocatedByPostgres>::alloc0() };
-
-    parquet_dest.dest.receiveSlot = Some(copy_receive);
-    parquet_dest.dest.rStartup = Some(copy_startup);
-    parquet_dest.dest.rShutdown = Some(copy_shutdown);
-    parquet_dest.dest.rDestroy = Some(copy_destroy);
-    parquet_dest.dest.mydest = CommandDest::DestCopyOut;
-    parquet_dest.uri = uri;
-    parquet_dest.tupledesc = std::ptr::null_mut();
-    parquet_dest.parquet_writer_context = std::ptr::null_mut();
-    parquet_dest.natts = 0;
-    parquet_dest.collected_tuple_count = 0;
-    parquet_dest.collected_tuples = std::ptr::null_mut();
-    parquet_dest.collected_tuple_column_sizes = std::ptr::null_mut();
-    parquet_dest.copy_options.row_group_size = row_group_size;
-    parquet_dest.copy_options.row_group_size_bytes = row_group_size_bytes;
-    parquet_dest.copy_options.compression = compression;
-    parquet_dest.copy_options.compression_level = compression_level;
-    parquet_dest.per_copy_context = per_copy_context;
-
-    unsafe { std::mem::transmute(parquet_dest) }
-}
+pub(crate) extern "C" fn copy_destroy(_dest: *mut DestReceiver) {}
 
 fn tuple_column_sizes(tuple_datums: &[Option<Datum>], tupledesc: &PgTupleDesc) -> Vec<i32> {
     let mut column_sizes = vec![];
@@ -362,4 +294,44 @@ fn tuple_column_sizes(tuple_datums: &[Option<Datum>], tupledesc: &PgTupleDesc) -
     }
 
     column_sizes
+}
+
+// create_copy_to_parquet_dest_receiver creates a new CopyToParquetDestReceiver that can be
+// used as a destination receiver for COPY TO command. All arguments, except "uri", are optional
+// and have default values if not provided.
+#[pg_guard]
+pub(crate) fn create_copy_to_parquet_dest_receiver(
+    uri: *const c_char,
+    options: CopyToParquetOptions,
+) -> *mut CopyToParquetDestReceiver {
+    let per_copy_context = unsafe {
+        AllocSetContextCreateExtended(
+            CurrentMemoryContext as _,
+            "ParquetCopyDestReceiver".as_pg_cstr(),
+            ALLOCSET_DEFAULT_MINSIZE as _,
+            ALLOCSET_DEFAULT_INITSIZE as _,
+            ALLOCSET_DEFAULT_MAXSIZE as _,
+        )
+    };
+
+    let mut parquet_dest =
+        unsafe { PgBox::<CopyToParquetDestReceiver, AllocatedByPostgres>::alloc0() };
+
+    parquet_dest.dest.receiveSlot = Some(copy_receive);
+    parquet_dest.dest.rStartup = Some(copy_startup);
+    parquet_dest.dest.rShutdown = Some(copy_shutdown);
+    parquet_dest.dest.rDestroy = Some(copy_destroy);
+    parquet_dest.dest.mydest = CommandDest::DestCopyOut;
+    parquet_dest.uri = uri;
+    parquet_dest.tupledesc = std::ptr::null_mut();
+    parquet_dest.parquet_writer_context = std::ptr::null_mut();
+    parquet_dest.natts = 0;
+    parquet_dest.collected_tuple_count = 0;
+    parquet_dest.collected_tuples = std::ptr::null_mut();
+    parquet_dest.collected_tuple_column_sizes = std::ptr::null_mut();
+    parquet_dest.target_batch_size = 0;
+    parquet_dest.copy_options = options;
+    parquet_dest.per_copy_context = per_copy_context;
+
+    parquet_dest.into_pg()
 }

--- a/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
+++ b/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
@@ -1,0 +1,260 @@
+use std::{
+    ffi::{c_char, CStr},
+    path::Path,
+};
+
+use pg_sys::{AsPgCStr, CommandDest, DestReceiver, TupleDesc, TupleTableSlot};
+use pgrx::prelude::*;
+
+use crate::arrow_parquet::{
+    compression::{PgParquetCompression, INVALID_COMPRESSION_LEVEL},
+    parquet_writer::{DEFAULT_ROW_GROUP_SIZE, DEFAULT_ROW_GROUP_SIZE_BYTES},
+};
+
+use super::copy_to_dest_receiver::{
+    create_copy_to_parquet_dest_receiver, CopyToParquetDestReceiver,
+};
+
+pub(crate) const INVALID_FILE_SIZE_BYTES: i64 = 0;
+
+#[repr(C)]
+struct CopyToParquetSplitDestReceiver {
+    dest: DestReceiver,
+    uri: *const c_char,
+    tupledesc: TupleDesc,
+    operation: i32,
+    options: CopyToParquetOptions,
+    current_child_id: i64,
+    current_child_receiver: *mut CopyToParquetDestReceiver,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub(crate) struct CopyToParquetOptions {
+    pub(crate) file_size_bytes: i64,
+    pub(crate) row_group_size: i64,
+    pub(crate) row_group_size_bytes: i64,
+    pub(crate) compression: PgParquetCompression,
+    pub(crate) compression_level: i32,
+}
+
+impl CopyToParquetSplitDestReceiver {
+    fn create_new_child(&mut self) {
+        // create a new child receiver
+        let child_uri = self.create_uri_for_child();
+        self.current_child_receiver = create_copy_to_parquet_dest_receiver(child_uri, self.options);
+        self.current_child_id += 1;
+
+        // start the child receiver
+        let child_parquet_dest =
+            unsafe { PgBox::<DestReceiver>::from_pg(self.current_child_receiver as _) };
+
+        if let Some(child_startup_callback) = child_parquet_dest.rStartup {
+            unsafe {
+                child_startup_callback(child_parquet_dest.as_ptr(), self.operation, self.tupledesc);
+            }
+        }
+    }
+
+    fn should_create_new_child(&self) -> bool {
+        self.current_child_receiver.is_null()
+    }
+
+    fn send_tuple_to_child(&self, slot: *mut TupleTableSlot) {
+        debug_assert!(!self.current_child_receiver.is_null());
+
+        let child_parquet_dest =
+            unsafe { PgBox::<DestReceiver>::from_pg(self.current_child_receiver as _) };
+
+        if let Some(child_receive_callback) = child_parquet_dest.receiveSlot {
+            unsafe {
+                child_receive_callback(slot, child_parquet_dest.as_ptr());
+            }
+        }
+    }
+
+    fn flush_child(&mut self) {
+        if self.current_child_receiver.is_null() {
+            return;
+        }
+
+        // shutdown the current child receiver, which flushes collected tuples to parquet file.
+        let child_parquet_dest =
+            unsafe { PgBox::<DestReceiver>::from_pg(self.current_child_receiver as _) };
+
+        if let Some(child_shutdown_callback) = child_parquet_dest.rShutdown {
+            unsafe {
+                child_shutdown_callback(child_parquet_dest.as_ptr());
+            }
+        }
+
+        self.current_child_receiver = std::ptr::null_mut();
+    }
+
+    fn should_flush_child(&self) -> bool {
+        if self.options.file_size_bytes == INVALID_FILE_SIZE_BYTES {
+            return false;
+        }
+
+        debug_assert!(!self.current_child_receiver.is_null());
+
+        let child_parquet_dest = unsafe {
+            PgBox::<CopyToParquetDestReceiver>::from_pg(self.current_child_receiver as _)
+        };
+
+        child_parquet_dest.collected_bytes() as i64 > self.options.file_size_bytes
+    }
+
+    fn create_uri_for_child(&self) -> *const c_char {
+        // file_size_bytes not specified, use the original uri
+        if self.options.file_size_bytes == INVALID_FILE_SIZE_BYTES {
+            return self.uri;
+        }
+
+        let uri = unsafe { CStr::from_ptr(self.uri) }
+            .to_str()
+            .expect("invalid uri");
+
+        let file_name = Path::new(uri)
+            .file_name()
+            .expect("invalid uri")
+            .to_str()
+            .expect("invalid uri");
+
+        let (file_name_prefix, file_extension) = match file_name.find('.') {
+            Some(index) => file_name.split_at(index),
+            None => (file_name, ""),
+        };
+
+        let parent_folder = Path::new(uri)
+            .parent()
+            .expect("invalid uri")
+            .join(file_name_prefix);
+
+        // append child id to final part of uri
+        let file_id = self.current_child_id;
+
+        let child_uri = parent_folder.join(format!("data_{file_id}{file_extension}"));
+
+        child_uri.to_str().expect("invalid uri").as_pg_cstr()
+    }
+}
+
+#[pg_guard]
+extern "C" fn copy_split_startup(dest: *mut DestReceiver, operation: i32, tupledesc: TupleDesc) {
+    let split_parquet_dest = unsafe {
+        (dest as *mut CopyToParquetSplitDestReceiver)
+            .as_mut()
+            .expect("invalid split parquet dest receiver ptr")
+    };
+
+    // update the parquet split dest receiver's missing fields
+    split_parquet_dest.operation = operation;
+    split_parquet_dest.tupledesc = tupledesc;
+    split_parquet_dest.create_new_child();
+}
+
+#[pg_guard]
+extern "C" fn copy_split_receive(slot: *mut TupleTableSlot, dest: *mut DestReceiver) -> bool {
+    let split_parquet_dest = unsafe {
+        (dest as *mut CopyToParquetSplitDestReceiver)
+            .as_mut()
+            .expect("invalid split parquet dest receiver ptr")
+    };
+
+    if split_parquet_dest.should_create_new_child() {
+        split_parquet_dest.create_new_child();
+    }
+
+    split_parquet_dest.send_tuple_to_child(slot);
+
+    if split_parquet_dest.should_flush_child() {
+        split_parquet_dest.flush_child();
+    }
+
+    true
+}
+
+#[pg_guard]
+extern "C" fn copy_split_shutdown(dest: *mut DestReceiver) {
+    let split_parquet_dest = unsafe {
+        (dest as *mut CopyToParquetSplitDestReceiver)
+            .as_mut()
+            .expect("invalid split parquet dest receiver ptr")
+    };
+
+    split_parquet_dest.flush_child();
+}
+
+#[pg_guard]
+extern "C" fn copy_split_destroy(_dest: *mut DestReceiver) {}
+
+// create_copy_to_parquet_split_dest_receiver creates a new CopyToParquetSplitDestReceiver that can be
+// used as a destination receiver for COPY TO command. All arguments, except "uri", are optional
+// and have default values if not provided.
+#[pg_guard]
+#[no_mangle]
+pub extern "C" fn create_copy_to_parquet_split_dest_receiver(
+    uri: *const c_char,
+    file_size_bytes: *const i64,
+    row_group_size: *const i64,
+    row_group_size_bytes: *const i64,
+    compression: *const PgParquetCompression,
+    compression_level: *const i32,
+) -> *mut DestReceiver {
+    let file_size_bytes = if file_size_bytes.is_null() {
+        INVALID_FILE_SIZE_BYTES
+    } else {
+        unsafe { *file_size_bytes }
+    };
+
+    let row_group_size = if row_group_size.is_null() {
+        DEFAULT_ROW_GROUP_SIZE
+    } else {
+        unsafe { *row_group_size }
+    };
+
+    let row_group_size_bytes = if row_group_size_bytes.is_null() {
+        DEFAULT_ROW_GROUP_SIZE_BYTES
+    } else {
+        unsafe { *row_group_size_bytes }
+    };
+
+    let compression = if compression.is_null() {
+        PgParquetCompression::default()
+    } else {
+        unsafe { *compression }
+    };
+
+    let compression_level = if compression_level.is_null() {
+        compression
+            .default_compression_level()
+            .unwrap_or(INVALID_COMPRESSION_LEVEL)
+    } else {
+        unsafe { *compression_level }
+    };
+
+    let options = CopyToParquetOptions {
+        file_size_bytes,
+        row_group_size,
+        row_group_size_bytes,
+        compression,
+        compression_level,
+    };
+
+    let mut split_dest =
+        unsafe { PgBox::<CopyToParquetSplitDestReceiver, AllocatedByPostgres>::alloc0() };
+
+    split_dest.dest.receiveSlot = Some(copy_split_receive);
+    split_dest.dest.rStartup = Some(copy_split_startup);
+    split_dest.dest.rShutdown = Some(copy_split_shutdown);
+    split_dest.dest.rDestroy = Some(copy_split_destroy);
+    split_dest.dest.mydest = CommandDest::DestCopyOut;
+    split_dest.uri = uri;
+    split_dest.tupledesc = std::ptr::null_mut();
+    split_dest.operation = -1;
+    split_dest.options = options;
+    split_dest.current_child_id = 0;
+
+    unsafe { std::mem::transmute(split_dest) }
+}

--- a/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
+++ b/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
@@ -115,26 +115,11 @@ impl CopyToParquetSplitDestReceiver {
             .to_str()
             .expect("invalid uri");
 
-        let file_name = Path::new(uri)
-            .file_name()
-            .expect("invalid uri")
-            .to_str()
-            .expect("invalid uri");
+        let parent_folder = Path::new(uri);
 
-        let (file_name_prefix, file_extension) = match file_name.find('.') {
-            Some(index) => file_name.split_at(index),
-            None => (file_name, ""),
-        };
-
-        let parent_folder = Path::new(uri)
-            .parent()
-            .expect("invalid uri")
-            .join(file_name_prefix);
-
-        // append child id to final part of uri
         let file_id = self.current_child_id;
 
-        let child_uri = parent_folder.join(format!("data_{file_id}{file_extension}"));
+        let child_uri = parent_folder.join(format!("data_{file_id}.parquet"));
 
         child_uri.to_str().expect("invalid uri").as_pg_cstr()
     }

--- a/src/parquet_copy_hook/copy_utils.rs
+++ b/src/parquet_copy_hook/copy_utils.rs
@@ -64,13 +64,16 @@ pub(crate) fn validate_copy_to_options(p_stmt: &PgBox<PlannedStmt>, uri_info: Pa
     let file_size_bytes_option = copy_stmt_get_option(p_stmt, "file_size_bytes");
 
     if !file_size_bytes_option.is_null() {
-        let file_size_bytes = unsafe { defGetInt64(file_size_bytes_option.as_ptr()) };
+        let file_size_bytes = unsafe { defGetString(file_size_bytes_option.as_ptr()) };
 
-        const ONE_MB: i64 = 1024 * 1024;
+        let file_size_bytes = unsafe {
+            CStr::from_ptr(file_size_bytes)
+                .to_str()
+                .expect("file_size_bytes option is not a valid CString")
+        };
 
-        if file_size_bytes < ONE_MB {
-            panic!("file_size_bytes must be at least {ONE_MB} bytes");
-        }
+        parse_file_size(file_size_bytes)
+            .unwrap_or_else(|e| panic!("file_size_bytes option is not valid: {}", e));
     }
 
     let row_group_size_option = copy_stmt_get_option(p_stmt, "row_group_size");
@@ -204,7 +207,16 @@ pub(crate) fn copy_to_stmt_file_size_bytes(p_stmt: &PgBox<PlannedStmt>) -> i64 {
     if file_size_bytes_option.is_null() {
         INVALID_FILE_SIZE_BYTES
     } else {
-        unsafe { defGetInt64(file_size_bytes_option.as_ptr()) }
+        let file_size_bytes = unsafe { defGetString(file_size_bytes_option.as_ptr()) };
+
+        let file_size_bytes = unsafe {
+            CStr::from_ptr(file_size_bytes)
+                .to_str()
+                .expect("file_size_bytes option is not a valid CString")
+        };
+
+        parse_file_size(file_size_bytes)
+            .unwrap_or_else(|e| panic!("file_size_bytes option is not valid: {}", e)) as i64
     }
 }
 
@@ -589,4 +601,56 @@ pub(crate) fn create_filtered_tupledesc_for_relation<'a>(
     }
 
     filtered_tupledesc
+}
+
+/// Parses a size string like "1MB", "512KB", or just "1000000" into a byte count.
+/// Enforces a minimum of 1MB.
+fn parse_file_size(size_str: &str) -> Result<u64, String> {
+    // Normalize casing and trim whitespace
+    let size_str = size_str.trim().to_uppercase();
+
+    // Find the first non-digit character
+    let mut idx = 0;
+    for c in size_str.chars() {
+        if !c.is_ascii_digit() {
+            break;
+        }
+        idx += 1;
+    }
+
+    // If there's no numeric portion, return an error
+    if idx == 0 {
+        return Err(format!("No numeric value found in '{}'", size_str));
+    }
+
+    // Split into numeric part and (optional) unit
+    let num_part = &size_str[..idx];
+    let unit_part = size_str[idx..].trim();
+
+    // Convert the numeric portion
+    let mut bytes = match num_part.parse::<u64>() {
+        Ok(n) => n,
+        Err(_) => return Err(format!("Invalid numeric portion in '{}'", size_str)),
+    };
+
+    // Interpret the suffix, if present
+    match unit_part {
+        "" => { /* no suffix: treat as bytes */ }
+        "KB" => bytes *= 1_024,
+        "MB" => bytes *= 1_024 * 1_024,
+        "GB" => bytes *= 1_024 * 1_024 * 1_024,
+        _ => {
+            return Err(format!(
+                "Unrecognized unit '{}'. Allowed units are KB, MB or GB.",
+                unit_part
+            ))
+        }
+    }
+
+    // Enforce a minimum of 1MB
+    if bytes < 1_024 * 1_024 {
+        return Err(format!("Minimum allowed size is 1MB. Got {} bytes.", bytes));
+    }
+
+    Ok(bytes)
 }

--- a/src/pgrx_tests/common.rs
+++ b/src/pgrx_tests/common.rs
@@ -40,6 +40,7 @@ pub(crate) fn comma_separated_copy_options(options: &HashMap<String, CopyOptionV
 }
 
 pub(crate) const LOCAL_TEST_FILE_PATH: &str = "/tmp/pg_parquet_test.parquet";
+pub(crate) const LOCAL_TEST_FOLDER_PATH: &str = "/tmp/pg_parquet_test";
 
 pub(crate) struct TestTable<T: IntoDatum + FromDatum> {
     uri: String,

--- a/src/pgrx_tests/common.rs
+++ b/src/pgrx_tests/common.rs
@@ -40,7 +40,6 @@ pub(crate) fn comma_separated_copy_options(options: &HashMap<String, CopyOptionV
 }
 
 pub(crate) const LOCAL_TEST_FILE_PATH: &str = "/tmp/pg_parquet_test.parquet";
-pub(crate) const LOCAL_TEST_FOLDER_PATH: &str = "/tmp/pg_parquet_test";
 
 pub(crate) struct TestTable<T: IntoDatum + FromDatum> {
     uri: String,

--- a/src/pgrx_tests/copy_options.rs
+++ b/src/pgrx_tests/copy_options.rs
@@ -1,11 +1,13 @@
 #[pgrx::pg_schema]
 mod tests {
-    use std::collections::HashMap;
+    use std::{cmp::Ordering, collections::HashMap, path::Path};
 
     use pgrx::{pg_test, Spi};
 
     use crate::{
-        pgrx_tests::common::{CopyOptionValue, TestTable, LOCAL_TEST_FILE_PATH},
+        pgrx_tests::common::{
+            CopyOptionValue, TestTable, LOCAL_TEST_FILE_PATH, LOCAL_TEST_FOLDER_PATH,
+        },
         PgParquetCompression,
     };
 
@@ -280,6 +282,23 @@ mod tests {
     }
 
     #[pg_test]
+    #[should_panic(expected = "file_size_bytes must be at least 1048576 bytes")]
+    fn test_invalid_file_size_bytes() {
+        let parent_folder = Path::new(LOCAL_TEST_FOLDER_PATH);
+        std::fs::remove_dir_all(parent_folder).ok();
+
+        let mut copy_options = HashMap::new();
+        copy_options.insert(
+            "file_size_bytes".to_string(),
+            CopyOptionValue::IntOption(100),
+        );
+
+        let test_table = TestTable::<i32>::new("int4".into()).with_copy_to_options(copy_options);
+        test_table.insert("INSERT INTO test_expected (a) VALUES (1), (2), (null);");
+        test_table.assert_expected_and_result_rows();
+    }
+
+    #[pg_test]
     fn test_large_arrow_array_limit() {
         // disable row group size bytes limit
         let mut copy_options = HashMap::new();
@@ -312,7 +331,7 @@ mod tests {
             results
         });
 
-        assert_eq!(result_metadata, vec![2]);
+        assert_eq!(result_metadata, vec![1]);
     }
 
     #[pg_test]
@@ -362,7 +381,7 @@ mod tests {
 
         let id_bytes = 4;
         let name_bytes = 1;
-        let total_rows_size_bytes = (id_bytes + name_bytes) * 1_000_000;
+        let total_rows_size_bytes = (id_bytes + name_bytes) * 1024 * 1024;
 
         let row_group_size_bytes = total_rows_size_bytes / 10;
 
@@ -390,7 +409,108 @@ mod tests {
             results
         });
 
-        assert_eq!(result_metadata, vec![10]);
+        assert_eq!(result_metadata, vec![12]);
+    }
+
+    #[pg_test]
+    fn test_file_size_bytes() {
+        let parent_folder = Path::new(LOCAL_TEST_FOLDER_PATH);
+
+        let uris = [
+            // with ".parquet" extension
+            LOCAL_TEST_FILE_PATH.to_string(),
+            // with ".parquet.gz" extension
+            format!("{LOCAL_TEST_FILE_PATH}.gz"),
+            // without extension
+            LOCAL_TEST_FILE_PATH
+                .strip_suffix(".parquet")
+                .unwrap()
+                .to_string(),
+        ];
+
+        let expected_file_counts = [5_usize, 3, 5];
+
+        for (uri, expected_file_count) in uris.into_iter().zip(expected_file_counts) {
+            // cleanup
+            Spi::run("drop table if exists test_expected, test_result;").unwrap();
+            std::fs::remove_dir_all(parent_folder).ok();
+
+            const ONE_MB: i32 = 1024 * 1024;
+            let setup_commands = format!(
+                "create table test_expected(a text);\n\
+                 create table test_result(a text);\n\
+                 insert into test_expected select 'hellooooo' || i from generate_series(1, 1000000) i;\n\
+                 copy test_expected to '{uri}' with (format parquet, file_size_bytes {ONE_MB})");
+            Spi::run(&setup_commands).unwrap();
+
+            // assert file count
+            let file_name = Path::new(&uri)
+                .file_name()
+                .expect("invalid uri")
+                .to_str()
+                .expect("invalid uri");
+
+            let file_extension = file_name
+                .find('.')
+                .map(|idx| &file_name[idx..])
+                .unwrap_or("");
+
+            let mut file_entries = parent_folder
+                .read_dir()
+                .unwrap()
+                .map(|entry_res| entry_res.unwrap())
+                .collect::<Vec<_>>();
+
+            assert_eq!(file_entries.len(), expected_file_count);
+
+            file_entries.sort_by(|a, b| {
+                if a.file_name() <= b.file_name() {
+                    Ordering::Less
+                } else {
+                    Ordering::Greater
+                }
+            });
+
+            // assert file paths
+            for (file_idx, file_entry) in file_entries.iter().enumerate() {
+                let expected_path = parent_folder.join(format!("data_{file_idx}{file_extension}"));
+
+                let expected_path = expected_path.to_str().unwrap();
+
+                assert_eq!(file_entry.path().to_str().unwrap(), expected_path);
+
+                let copy_from_command =
+                    format!("copy test_result from '{expected_path}' with (format parquet)");
+                Spi::run(copy_from_command.as_str()).unwrap();
+            }
+
+            // assert rows
+            let (expected_rows, result_rows) = Spi::connect(|client| {
+                let mut expected_rows = Vec::new();
+                let tup_table = client
+                    .select("select a from test_expected order by 1", None, &[])
+                    .unwrap();
+
+                for row in tup_table {
+                    let a = row["a"].value::<&str>().unwrap().unwrap();
+                    expected_rows.push(a);
+                }
+
+                let mut result_rows = Vec::new();
+                let tup_table = client
+                    .select("select a from test_result order by 1", None, &[])
+                    .unwrap();
+
+                for row in tup_table {
+                    let a = row["a"].value::<&str>().unwrap().unwrap();
+                    result_rows.push(a);
+                }
+
+                (expected_rows, result_rows)
+            });
+
+            assert_eq!(result_rows, expected_rows);
+        }
     }
 
     #[pg_test]

--- a/src/pgrx_tests/copy_type_roundtrip.rs
+++ b/src/pgrx_tests/copy_type_roundtrip.rs
@@ -1217,8 +1217,6 @@ mod tests {
             results
         });
 
-        Spi::run("TRUNCATE dog_owners;").unwrap();
-
         let copy_to_query = format!(
             "COPY (SELECT owner FROM dog_owners) TO '{}' WITH (format parquet);",
             LOCAL_TEST_FILE_PATH


### PR DESCRIPTION
COPY TO parquet now supports a new option, called `file_size_bytes`, which lets you generate parquet files with target size = `file_size_bytes`.

When a parquet file exceeds the target size, it will be flushed and a new parquet file will be generated under a parent directory. (parent directory will be the path without the parquet extension)

e.g.

```sql
COPY (select 'hellooooo' || i from generate_series(1, 1000000) i) to '/tmp/test.parquet' with (file_size_bytes 1048576);
```

```bash
> ls -alh /tmp/test.parquet/
1.4M data_0.parquet
1.4M data_1.parquet
1.4M data_2.parquet
1.4M data_3.parquet
114K data_4.parquet
```

Closes #107.