### PR TITLE
Improved stats inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,25 +159,26 @@ SELECT uri, encode(key, 'escape') as key, encode(value, 'escape') as value FROM 
 ```
 
 ### Inspect Parquet column statistics
+
 You can call `SELECT * FROM parquet.column_stats(<uri>)` to discover the column statistics of the Parquet file, such as min and max value for the column, at given uri.
 
 ```sql
 SELECT * FROM parquet.column_stats('/tmp/product_example.parquet')
- field_id |         stats_min          |         stats_max          | stats_null_count | stats_distinct_count 
-----------+----------------------------+----------------------------+------------------+----------------------
-       19 | 2022-05-01 16:00:00        | 2022-05-01 16:00:00        |                0 |                     
-       15 |                            |                            |                2 |                     
-        3 | product 1                  | product 1                  |                0 |                     
-        2 | 1                          | 1                          |                0 |                     
-        0 | 1                          | 1                          |                0 |                     
-        6 | 1                          | 2                          |                1 |                     
-        7 | item 1                     | item 2                     |                1 |                     
-       16 |                            |                            |                2 |                     
-       12 |                            |                            |                2 |                     
-       18 | 2025-01-29 02:28:35.193773 | 2025-01-29 02:28:35.193773 |                0 |                     
-       11 | 1                          | 1                          |                1 |                     
-        8 | 1                          | 2                          |                1 |                     
-       17 |                            |                            |                2 |                     
+ column_id | field_id |         stats_min          |         stats_max          | stats_null_count | stats_distinct_count 
+-----------+----------+----------------------------+----------------------------+------------------+----------------------
+         4 |        7 | item 1                     | item 2                     |                1 |                     
+         6 |       11 | 1                          | 1                          |                1 |                     
+         7 |       12 |                            |                            |                2 |                     
+        10 |       17 |                            |                            |                2 |                     
+         0 |        0 | 1                          | 1                          |                0 |                     
+        11 |       18 | 2025-03-11 14:01:22.045739 | 2025-03-11 14:01:22.045739 |                0 |                     
+         3 |        6 | 1                          | 2                          |                1 |                     
+        12 |       19 | 2022-05-01 19:00:00+03     | 2022-05-01 19:00:00+03     |                0 |                     
+         8 |       15 |                            |                            |                2 |                     
+         5 |        8 | 1                          | 2                          |                1 |                     
+         9 |       16 |                            |                            |                2 |                     
+         1 |        2 | 1                          | 1                          |                0 |                     
+         2 |        3 | product 1                  | product 1                  |                0 |                     
 (13 rows)
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ COPY table FROM 's3://mybucket/data.parquet' WITH (format 'parquet');
   - [Copy FROM/TO Parquet files TO/FROM Postgres tables](#copy-tofrom-parquet-files-fromto-postgres-tables)
   - [Inspect Parquet schema](#inspect-parquet-schema)
   - [Inspect Parquet metadata](#inspect-parquet-metadata)
+  - [Inspect Parquet column statistics](#inspect-parquet-column-statistics)
 - [Object Store Support](#object-store-support)
 - [Copy Options](#copy-options)
 - [Configuration](#configuration)
@@ -155,6 +156,29 @@ SELECT uri, encode(key, 'escape') as key, encode(value, 'escape') as value FROM 
 ------------------------------+--------------+---------------------
  /tmp/product_example.parquet | ARROW:schema | /////5gIAAAQAAAA ...
 (1 row)
+```
+
+### Inspect Parquet column statistics
+You can call `SELECT * FROM parquet.column_stats(<uri>)` to discover the column statistics of the Parquet file, such as min and max value for the column, at given uri.
+
+```sql
+SELECT * FROM parquet.column_stats('/tmp/product_example.parquet')
+ field_id |         stats_min          |         stats_max          | stats_null_count | stats_distinct_count 
+----------+----------------------------+----------------------------+------------------+----------------------
+       19 | 2022-05-01 16:00:00        | 2022-05-01 16:00:00        |                0 |                     
+       15 |                            |                            |                2 |                     
+        3 | product 1                  | product 1                  |                0 |                     
+        2 | 1                          | 1                          |                0 |                     
+        0 | 1                          | 1                          |                0 |                     
+        6 | 1                          | 2                          |                1 |                     
+        7 | item 1                     | item 2                     |                1 |                     
+       16 |                            |                            |                2 |                     
+       12 |                            |                            |                2 |                     
+       18 | 2025-01-29 02:28:35.193773 | 2025-01-29 02:28:35.193773 |                0 |                     
+       11 | 1                          | 1                          |                1 |                     
+        8 | 1                          | 2                          |                1 |                     
+       17 |                            |                            |                2 |                     
+(13 rows)
 ```
 
 ## Object Store Support

--- a/src/parquet_udfs.rs
+++ b/src/parquet_udfs.rs
@@ -1,2 +1,3 @@
 pub(crate) mod metadata;
 pub(crate) mod schema;
+pub(crate) mod stats;

--- a/src/parquet_udfs/metadata.rs
+++ b/src/parquet_udfs/metadata.rs
@@ -1,13 +1,14 @@
 use pgrx::{iter::TableIterator, name, pg_extern, pg_schema};
 
-use crate::arrow_parquet::uri_utils::{
-    ensure_access_privilege_to_uri, parquet_metadata_from_uri, uri_as_string, ParsedUriInfo,
+use crate::{
+    arrow_parquet::uri_utils::{
+        ensure_access_privilege_to_uri, parquet_metadata_from_uri, uri_as_string, ParsedUriInfo,
+    },
+    parquet_udfs::stats::{stats_max_value_to_pg_str, stats_min_value_to_pg_str},
 };
 
 #[pg_schema]
 mod parquet {
-    use crate::parquet_udfs::stats::{stats_max_value_to_pg_str, stats_min_value_to_pg_str};
-
     use super::*;
 
     #[pg_extern]

--- a/src/parquet_udfs/stats.rs
+++ b/src/parquet_udfs/stats.rs
@@ -1,0 +1,514 @@
+use std::{collections::HashMap, ffi::CStr, fmt::Write};
+
+use ::parquet::{
+    basic::{ConvertedType, LogicalType},
+    file::statistics::Statistics,
+    schema::types::ColumnDescriptor,
+};
+use pgrx::{
+    iter::TableIterator,
+    name, pg_extern, pg_schema,
+    pg_sys::{getTypeOutputInfo, InvalidOid, OidOutputFunctionCall},
+    IntoDatum,
+};
+
+use crate::{
+    arrow_parquet::uri_utils::{
+        ensure_access_privilege_to_uri, parquet_metadata_from_uri, parse_uri,
+    },
+    type_compat::pg_arrow_type_conversions::{
+        i128_to_numeric, i32_to_date, i64_to_time, i64_to_timestamp, i64_to_timestamptz,
+        i64_to_timetz, make_numeric_typmod,
+    },
+};
+
+#[pg_schema]
+mod parquet {
+    use super::*;
+
+    #[pg_extern]
+    #[allow(clippy::type_complexity)]
+    fn column_stats(
+        uri: String,
+    ) -> TableIterator<
+        'static,
+        (
+            name!(field_id, i32),
+            name!(stats_min, Option<String>),
+            name!(stats_max, Option<String>),
+            name!(stats_null_count, Option<i64>),
+            name!(stats_distinct_count, Option<i64>),
+        ),
+    > {
+        let uri = parse_uri(&uri);
+
+        ensure_access_privilege_to_uri(&uri, true);
+        let parquet_metadata = parquet_metadata_from_uri(&uri);
+
+        let mut column_stats = HashMap::new();
+        let mut column_descriptors = HashMap::new();
+
+        for row_group in parquet_metadata.row_groups().iter() {
+            for column in row_group.columns().iter() {
+                if !column
+                    .column_descr_ptr()
+                    .self_type()
+                    .get_basic_info()
+                    .has_id()
+                {
+                    continue;
+                }
+
+                let field_id = column.column_descr_ptr().self_type().get_basic_info().id();
+
+                column_descriptors
+                    .entry(field_id)
+                    .or_insert(column.column_descr());
+
+                // column statistics exist for each leaf column per row group
+                column_stats
+                    .entry(field_id)
+                    .or_insert_with(Vec::new)
+                    .push(column.statistics());
+            }
+        }
+
+        let mut stats_rows = Vec::new();
+
+        for (field_id, stats) in column_stats.iter_mut() {
+            let column_descriptor = column_descriptors
+                .get(field_id)
+                .expect("column descriptor not found");
+
+            stats_rows.push((
+                *field_id,
+                stats_min_value_aggregated_by_row_groups(stats, column_descriptor),
+                stats_max_value_aggregated_by_row_groups(stats, column_descriptor),
+                stats_null_count_aggregated_by_row_groups(stats),
+                stats_distinct_count_aggregated_by_row_groups(stats),
+            ));
+        }
+
+        TableIterator::new(stats_rows)
+    }
+}
+
+fn stats_null_count_aggregated_by_row_groups(stats: &[Option<&Statistics>]) -> Option<i64> {
+    let mut null_count_sum = None;
+
+    for stat in stats.iter().flatten() {
+        if let Some(null_count) = stat.null_count_opt() {
+            null_count_sum = match null_count_sum {
+                Some(sum) => Some(sum + null_count as i64),
+                None => Some(null_count as i64),
+            };
+        }
+    }
+
+    null_count_sum
+}
+
+fn stats_distinct_count_aggregated_by_row_groups(stats: &[Option<&Statistics>]) -> Option<i64> {
+    let mut distinct_count_sum = None;
+
+    for stat in stats.iter().flatten() {
+        if let Some(distinct_count) = stat.distinct_count_opt() {
+            distinct_count_sum = match distinct_count_sum {
+                Some(sum) => Some(sum + distinct_count as i64),
+                None => Some(distinct_count as i64),
+            };
+        }
+    }
+
+    distinct_count_sum
+}
+
+fn stats_min_value_aggregated_by_row_groups(
+    row_group_stats: &[Option<&Statistics>],
+    column_descriptor: &ColumnDescriptor,
+) -> Option<String> {
+    let mut min_value = None;
+
+    for stat in row_group_stats.iter().flatten() {
+        if let Some(current_min_value) = min_value {
+            min_value = Some(stats_min_of_two(current_min_value, stat));
+        } else {
+            min_value = Some(*stat);
+        }
+    }
+
+    min_value.and_then(|v| stats_min_value_to_pg_str(v, column_descriptor))
+}
+
+fn stats_max_value_aggregated_by_row_groups(
+    row_group_stats: &[Option<&Statistics>],
+    column_descriptor: &ColumnDescriptor,
+) -> Option<String> {
+    let mut max_value = None;
+
+    for stat in row_group_stats.iter().flatten() {
+        if let Some(current_max_value) = max_value {
+            max_value = Some(stats_max_of_two(current_max_value, stat));
+        } else {
+            max_value = Some(*stat);
+        }
+    }
+
+    max_value.and_then(|v| stats_max_value_to_pg_str(v, column_descriptor))
+}
+
+pub(crate) fn stats_min_value_to_pg_str(
+    statistics: &Statistics,
+    column_descriptor: &ColumnDescriptor,
+) -> Option<String> {
+    let logical_type = column_descriptor.logical_type();
+
+    let converted_type = column_descriptor.converted_type();
+
+    let is_string = matches!(logical_type, Some(LogicalType::String))
+        || matches!(converted_type, ConvertedType::UTF8);
+
+    let is_date = matches!(logical_type, Some(LogicalType::Date))
+        || matches!(converted_type, ConvertedType::DATE);
+
+    let is_timestamp = matches!(
+        logical_type,
+        Some(LogicalType::Timestamp {
+            is_adjusted_to_u_t_c,
+            ..
+        }) if !is_adjusted_to_u_t_c
+    );
+
+    let is_timestamptz = matches!(
+        logical_type,
+        Some(LogicalType::Timestamp {
+            is_adjusted_to_u_t_c,
+            ..
+        }) if is_adjusted_to_u_t_c
+    );
+
+    let is_time = matches!(
+        logical_type,
+        Some(LogicalType::Time {
+            is_adjusted_to_u_t_c,
+            ..
+        }) if !is_adjusted_to_u_t_c
+    );
+
+    let is_timetz = matches!(
+        logical_type,
+        Some(LogicalType::Time {
+            is_adjusted_to_u_t_c,
+            ..
+        }) if is_adjusted_to_u_t_c
+    );
+
+    let is_numeric = matches!(logical_type, Some(LogicalType::Decimal { .. }))
+        || matches!(converted_type, ConvertedType::DECIMAL);
+
+    match statistics {
+        Statistics::Boolean(statistics) => statistics.min_opt().map(|v| v.to_string()),
+        Statistics::Int32(statistics) => statistics.min_opt().map(|v| {
+            if is_date {
+                pg_format(i32_to_date(*v))
+            } else if is_numeric {
+                pg_format_numeric(*v as i128, column_descriptor)
+            } else {
+                v.to_string()
+            }
+        }),
+        Statistics::Int64(statistics) => statistics.min_opt().map(|v| {
+            if is_timestamp {
+                pg_format(i64_to_timestamp(*v))
+            } else if is_timestamptz {
+                pg_format(i64_to_timestamptz(*v, "UTC"))
+            } else if is_numeric {
+                pg_format_numeric(*v as i128, column_descriptor)
+            } else if is_time {
+                pg_format(i64_to_time(*v))
+            } else if is_timetz {
+                pg_format(i64_to_timetz(*v))
+            } else {
+                v.to_string()
+            }
+        }),
+        Statistics::Int96(statistics) => statistics.min_opt().map(|v| v.to_string()),
+        Statistics::Float(statistics) => statistics.min_opt().map(|v| v.to_string()),
+        Statistics::Double(statistics) => statistics.min_opt().map(|v| v.to_string()),
+        Statistics::ByteArray(statistics) => statistics.min_opt().map(|v| {
+            if is_string {
+                v.as_utf8()
+                    .unwrap_or_else(|e| panic!("cannot convert stats to utf8 {e}"))
+                    .to_string()
+            } else {
+                hex_encode(v.data())
+            }
+        }),
+        Statistics::FixedLenByteArray(statistics) => statistics.min_opt().map(|v| {
+            if is_string {
+                v.as_utf8()
+                    .unwrap_or_else(|e| panic!("cannot convert stats to utf8 {e}"))
+                    .to_string()
+            } else if is_numeric {
+                let mut numeric_bytes: [u8; 16] = [0; 16];
+
+                let offset = numeric_bytes.len() - v.data().len();
+                numeric_bytes[offset..].copy_from_slice(v.data());
+
+                let numeric = i128::from_be_bytes(numeric_bytes);
+
+                pg_format_numeric(numeric, column_descriptor)
+            } else {
+                hex_encode(v.data())
+            }
+        }),
+    }
+}
+
+pub(crate) fn stats_max_value_to_pg_str(
+    statistics: &Statistics,
+    column_descriptor: &ColumnDescriptor,
+) -> Option<String> {
+    let logical_type = column_descriptor.logical_type();
+
+    let converted_type = column_descriptor.converted_type();
+
+    let is_string = matches!(logical_type, Some(LogicalType::String))
+        || matches!(converted_type, ConvertedType::UTF8);
+
+    let is_date = matches!(logical_type, Some(LogicalType::Date))
+        || matches!(converted_type, ConvertedType::DATE);
+
+    let is_timestamp = matches!(
+        logical_type,
+        Some(LogicalType::Timestamp {
+            is_adjusted_to_u_t_c,
+            ..
+        }) if !is_adjusted_to_u_t_c
+    );
+
+    let is_timestamptz = matches!(
+        logical_type,
+        Some(LogicalType::Timestamp {
+            is_adjusted_to_u_t_c,
+            ..
+        }) if is_adjusted_to_u_t_c
+    );
+
+    let is_time = matches!(
+        logical_type,
+        Some(LogicalType::Time {
+            is_adjusted_to_u_t_c,
+            ..
+        }) if !is_adjusted_to_u_t_c
+    );
+
+    let is_timetz = matches!(
+        logical_type,
+        Some(LogicalType::Time {
+            is_adjusted_to_u_t_c,
+            ..
+        }) if is_adjusted_to_u_t_c
+    );
+
+    let is_numeric = matches!(logical_type, Some(LogicalType::Decimal { .. }))
+        || matches!(converted_type, ConvertedType::DECIMAL);
+
+    match statistics {
+        Statistics::Boolean(statistics) => statistics.max_opt().map(|v| v.to_string()),
+        Statistics::Int32(statistics) => statistics.max_opt().map(|v| {
+            if is_date {
+                pg_format(i32_to_date(*v))
+            } else if is_numeric {
+                pg_format_numeric(*v as i128, column_descriptor)
+            } else {
+                v.to_string()
+            }
+        }),
+        Statistics::Int64(statistics) => statistics.max_opt().map(|v| {
+            if is_timestamp {
+                pg_format(i64_to_timestamp(*v))
+            } else if is_timestamptz {
+                pg_format(i64_to_timestamptz(*v, "UTC"))
+            } else if is_numeric {
+                pg_format_numeric(*v as i128, column_descriptor)
+            } else if is_time {
+                pg_format(i64_to_time(*v))
+            } else if is_timetz {
+                pg_format(i64_to_timetz(*v))
+            } else {
+                v.to_string()
+            }
+        }),
+        Statistics::Int96(statistics) => statistics.max_opt().map(|v| v.to_string()),
+        Statistics::Float(statistics) => statistics.max_opt().map(|v| v.to_string()),
+        Statistics::Double(statistics) => statistics.max_opt().map(|v| v.to_string()),
+        Statistics::ByteArray(statistics) => statistics.max_opt().map(|v| {
+            if is_string {
+                v.as_utf8()
+                    .unwrap_or_else(|e| panic!("cannot convert stats to utf8 {e}"))
+                    .to_string()
+            } else {
+                hex_encode(v.data())
+            }
+        }),
+        Statistics::FixedLenByteArray(statistics) => statistics.max_opt().map(|v| {
+            if is_string {
+                v.as_utf8()
+                    .unwrap_or_else(|e| panic!("cannot convert stats to utf8 {e}"))
+                    .to_string()
+            } else if is_numeric {
+                let mut numeric_bytes: [u8; 16] = [0; 16];
+
+                let offset = numeric_bytes.len() - v.data().len();
+                numeric_bytes[offset..].copy_from_slice(v.data());
+
+                let numeric = i128::from_be_bytes(numeric_bytes);
+
+                pg_format_numeric(numeric, column_descriptor)
+            } else {
+                hex_encode(v.data())
+            }
+        }),
+    }
+}
+
+macro_rules! stats_max_helper {
+    ($stats_a:ident, $stats_b:ident, $a_max_val:ident, $b_max_val:ident) => {
+        match ($a_max_val.max_opt(), $b_max_val.max_opt()) {
+            (Some(a), Some(b)) => {
+                if *a > *b {
+                    $stats_a
+                } else {
+                    $stats_b
+                }
+            }
+            (Some(_), None) => $stats_a,
+            (None, Some(_)) => $stats_b,
+            (None, None) => $stats_a,
+        }
+    };
+}
+
+macro_rules! stats_min_helper {
+    ($stats_a:ident, $stats_b:ident, $a_min_val:ident, $b_min_val:ident) => {
+        match ($a_min_val.min_opt(), $b_min_val.min_opt()) {
+            (Some(a), Some(b)) => {
+                if *a < *b {
+                    $stats_a
+                } else {
+                    $stats_b
+                }
+            }
+            (Some(_), None) => $stats_a,
+            (None, Some(_)) => $stats_b,
+            (None, None) => $stats_a,
+        }
+    };
+}
+
+fn stats_max_of_two<'b, 'a: 'b>(
+    stats_a: &'a Statistics,
+    stats_b: &'b Statistics,
+) -> &'b Statistics {
+    match (stats_a, stats_b) {
+        (Statistics::Boolean(a_max), Statistics::Boolean(b_max)) => {
+            stats_max_helper!(stats_a, stats_b, a_max, b_max)
+        }
+        (Statistics::Int32(a_max), Statistics::Int32(b_max)) => {
+            stats_max_helper!(stats_a, stats_b, a_max, b_max)
+        }
+        (Statistics::Int64(a_max), Statistics::Int64(b_max)) => {
+            stats_max_helper!(stats_a, stats_b, a_max, b_max)
+        }
+        (Statistics::Int96(a_max), Statistics::Int96(b_max)) => {
+            stats_max_helper!(stats_a, stats_b, a_max, b_max)
+        }
+        (Statistics::Float(a_max), Statistics::Float(b_max)) => {
+            stats_max_helper!(stats_a, stats_b, a_max, b_max)
+        }
+        (Statistics::Double(a_max), Statistics::Double(b_max)) => {
+            stats_max_helper!(stats_a, stats_b, a_max, b_max)
+        }
+        (Statistics::ByteArray(a_max), Statistics::ByteArray(b_max)) => {
+            stats_max_helper!(stats_a, stats_b, a_max, b_max)
+        }
+        (Statistics::FixedLenByteArray(a_max), Statistics::FixedLenByteArray(b_max)) => {
+            stats_max_helper!(stats_a, stats_b, a_max, b_max)
+        }
+        _ => panic!("unexpected statistics comparison"),
+    }
+}
+
+fn stats_min_of_two<'b, 'a: 'b>(
+    stats_a: &'a Statistics,
+    stats_b: &'b Statistics,
+) -> &'b Statistics {
+    match (stats_a, stats_b) {
+        (Statistics::Boolean(a_min), Statistics::Boolean(b_min)) => {
+            stats_min_helper!(stats_a, stats_b, a_min, b_min)
+        }
+        (Statistics::Int32(a_min), Statistics::Int32(b_min)) => {
+            stats_min_helper!(stats_a, stats_b, a_min, b_min)
+        }
+        (Statistics::Int64(a_min), Statistics::Int64(b_min)) => {
+            stats_min_helper!(stats_a, stats_b, a_min, b_min)
+        }
+        (Statistics::Int96(a_min), Statistics::Int96(b_min)) => {
+            stats_min_helper!(stats_a, stats_b, a_min, b_min)
+        }
+        (Statistics::Float(a_min), Statistics::Float(b_min)) => {
+            stats_min_helper!(stats_a, stats_b, a_min, b_min)
+        }
+        (Statistics::Double(a_min), Statistics::Double(b_min)) => {
+            stats_min_helper!(stats_a, stats_b, a_min, b_min)
+        }
+        (Statistics::ByteArray(a_min), Statistics::ByteArray(b_min)) => {
+            stats_min_helper!(stats_a, stats_b, a_min, b_min)
+        }
+        (Statistics::FixedLenByteArray(a_min), Statistics::FixedLenByteArray(b_min)) => {
+            stats_min_helper!(stats_a, stats_b, a_min, b_min)
+        }
+        _ => panic!("unexpected statistics comparison"),
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().fold("\\x".into(), |mut output, b| {
+        let _ = write!(output, "{b:02X}");
+        output
+    })
+}
+
+fn pg_format<T: IntoDatum>(val: T) -> String {
+    let mut typoutput_func = InvalidOid;
+    let mut varlena = false;
+    unsafe {
+        getTypeOutputInfo(T::type_oid(), &mut typoutput_func, &mut varlena);
+
+        let output = OidOutputFunctionCall(
+            typoutput_func,
+            val.into_datum().expect("invalid stats datum"),
+        );
+
+        CStr::from_ptr(output)
+            .to_str()
+            .expect("invalid stats string")
+            .to_string()
+    }
+}
+
+fn pg_format_numeric(numeric: i128, column_descriptor: &ColumnDescriptor) -> String {
+    let precision = column_descriptor.type_precision();
+
+    let scale = column_descriptor.type_scale();
+
+    let typmod = make_numeric_typmod(precision, scale);
+
+    pg_format(i128_to_numeric(
+        numeric,
+        precision as u32,
+        scale as u32,
+        typmod,
+    ))
+}

--- a/src/pgrx_tests/udfs.rs
+++ b/src/pgrx_tests/udfs.rs
@@ -752,6 +752,9 @@ mod tests {
         let series_end = 89;
         let row_group_size = 10;
 
+        // set timezone to UTC
+        Spi::run("set timezone to 'UTC';").unwrap();
+
         let ddls = format!(
             "
             create type person AS (id int, name text);
@@ -834,33 +837,87 @@ mod tests {
         let result_column_stats = Spi::connect(|client| {
             let mut results = Vec::new();
             let tup_table = client
-                .select(&parquet_column_stats_command, None, None)
+                .select(&parquet_column_stats_command, None, &[])
                 .unwrap();
 
             for row in tup_table {
+                let column_id = row["column_id"].value::<i32>().unwrap().unwrap();
                 let field_id = row["field_id"].value::<i32>().unwrap().unwrap();
                 let stats_min = row["stats_min"].value::<String>().unwrap();
                 let stats_max = row["stats_max"].value::<String>().unwrap();
                 let null_count = row["stats_null_count"].value::<i64>().unwrap();
                 let distinct_count = row["stats_distinct_count"].value::<i64>().unwrap();
 
-                results.push((field_id, stats_min, stats_max, null_count, distinct_count));
+                results.push((
+                    column_id,
+                    field_id,
+                    stats_min,
+                    stats_max,
+                    null_count,
+                    distinct_count,
+                ));
             }
 
             results
         });
 
+        // reset timezone
+        Spi::run("reset timezone;").unwrap();
+
         let expected_column_stats = vec![
-            (0, Some("10".into()), Some("89".into()), Some(2), None),
-            (1, Some("10".into()), Some("89".into()), Some(2), None),
-            (2, Some("10".into()), Some("89".into()), Some(2), None),
-            (3, Some("12.1".into()), Some("12.89".into()), Some(2), None),
-            (4, Some("12.1".into()), Some("12.89".into()), Some(2), None),
-            (5, Some("12.10".into()), Some("12.89".into()), Some(2), None),
-            (6, Some("12.10".into()), Some("12.89".into()), Some(2), None),
-            (7, Some("12.10".into()), Some("12.89".into()), Some(2), None),
-            (8, Some("12.10".into()), Some("12.89".into()), Some(2), None),
+            (0, 0, Some("10".into()), Some("89".into()), Some(2), None),
+            (1, 1, Some("10".into()), Some("89".into()), Some(2), None),
+            (2, 2, Some("10".into()), Some("89".into()), Some(2), None),
             (
+                3,
+                3,
+                Some("12.1".into()),
+                Some("12.89".into()),
+                Some(2),
+                None,
+            ),
+            (
+                4,
+                4,
+                Some("12.1".into()),
+                Some("12.89".into()),
+                Some(2),
+                None,
+            ),
+            (
+                5,
+                5,
+                Some("12.10".into()),
+                Some("12.89".into()),
+                Some(2),
+                None,
+            ),
+            (
+                6,
+                6,
+                Some("12.10".into()),
+                Some("12.89".into()),
+                Some(2),
+                None,
+            ),
+            (
+                7,
+                7,
+                Some("12.10".into()),
+                Some("12.89".into()),
+                Some(2),
+                None,
+            ),
+            (
+                8,
+                8,
+                Some("12.10".into()),
+                Some("12.89".into()),
+                Some(2),
+                None,
+            ),
+            (
+                9,
                 9,
                 Some("12.100000000".into()),
                 Some("12.890000000".into()),
@@ -869,12 +926,14 @@ mod tests {
             ),
             (
                 10,
+                10,
                 Some("CrunchyData10".into()),
                 Some("CrunchyData89".into()),
                 Some(2),
                 None,
             ),
             (
+                11,
                 11,
                 Some("CrunchyData10".into()),
                 Some("CrunchyData89".into()),
@@ -883,12 +942,14 @@ mod tests {
             ),
             (
                 12,
+                12,
                 Some("2010-01-02".into()),
                 Some("2089-01-02".into()),
                 Some(2),
                 None,
             ),
             (
+                13,
                 13,
                 Some("2010-01-02 00:00:00".into()),
                 Some("2089-01-02 00:00:00".into()),
@@ -897,12 +958,14 @@ mod tests {
             ),
             (
                 14,
-                Some("2010-01-02 05:00:00+02".into()),
-                Some("2089-01-02 06:00:00+03".into()),
+                14,
+                Some("2010-01-02 03:00:00+00".into()),
+                Some("2089-01-02 03:00:00+00".into()),
                 Some(2),
                 None,
             ),
             (
+                15,
                 15,
                 Some("01:02:00".into()),
                 Some("01:02:59".into()),
@@ -911,15 +974,24 @@ mod tests {
             ),
             (
                 16,
+                16,
                 Some("22:02:00+00".into()),
                 Some("22:02:59+00".into()),
                 Some(2),
                 None,
             ),
-            (17, Some("10".into()), Some("89".into()), Some(2), None),
-            (18, Some("false".into()), Some("true".into()), Some(2), None),
-            (19, Some("\n".into()), Some("Y".into()), Some(2), None),
+            (17, 17, Some("10".into()), Some("89".into()), Some(2), None),
             (
+                18,
+                18,
+                Some("false".into()),
+                Some("true".into()),
+                Some(2),
+                None,
+            ),
+            (19, 19, Some("\n".into()), Some("Y".into()), Some(2), None),
+            (
+                20,
                 20,
                 Some("\\x010210".into()),
                 Some("\\x010289".into()),
@@ -928,14 +1000,16 @@ mod tests {
             ),
             (
                 21,
+                21,
                 Some("\\x095C270A".into()),
                 Some("\\x095C2759".into()),
                 Some(2),
                 None,
             ),
-            (23, Some("10".into()), Some("91".into()), Some(2), None),
-            (25, Some("10".into()), Some("89".into()), Some(2), None),
+            (22, 23, Some("10".into()), Some("91".into()), Some(2), None),
+            (23, 25, Some("10".into()), Some("89".into()), Some(2), None),
             (
+                24,
                 26,
                 Some("CrunchyData10".into()),
                 Some("CrunchyData89".into()),
@@ -943,6 +1017,7 @@ mod tests {
                 None,
             ),
             (
+                25,
                 27,
                 Some("(10,11)".into()),
                 Some("(89,90)".into()),
@@ -950,6 +1025,7 @@ mod tests {
                 None,
             ),
             (
+                26,
                 28,
                 Some("{\"key\":10}".into()),
                 Some("{\"key\":89}".into()),
@@ -957,13 +1033,15 @@ mod tests {
                 None,
             ),
             (
+                27,
                 29,
-                Some("{\"key\": 10}".into()),
-                Some("{\"key\": 89}".into()),
+                Some("{\"key\":10}".into()),
+                Some("{\"key\":89}".into()),
                 Some(2),
                 None,
             ),
             (
+                28,
                 30,
                 Some("041761f3-d843-49c7-bbd3-c50c86ec3410".into()),
                 Some("041761f3-d843-49c7-bbd3-c50c86ec3489".into()),

--- a/src/pgrx_tests/udfs.rs
+++ b/src/pgrx_tests/udfs.rs
@@ -745,4 +745,235 @@ mod tests {
 
         Spi::run("DROP TABLE workers; DROP TYPE worker, person;").unwrap();
     }
+
+    #[pg_test]
+    fn test_parquet_column_stats() {
+        let series_start = 10;
+        let series_end = 89;
+        let row_group_size = 10;
+
+        let ddls = format!(
+            "
+            create type person AS (id int, name text);
+            create table column_stats_test (
+                a smallint,
+                b int,
+                c bigint,
+                d float4,
+                e float8,
+                f numeric(5,2),
+                g numeric(12,2),
+                h numeric(25,2),
+                i numeric(40,2),
+                j numeric,
+                k text,
+                l varchar,
+                m date,
+                n timestamp,
+                o timestamptz,
+                p time,
+                q timetz,
+                r oid,
+                s bool,
+                t \"char\",
+                u bytea,
+                u_escaped bytea,
+                v int[],
+                w person,
+                x point,
+                y json,
+                z jsonb,
+                zz uuid);
+
+            -- default are all nulls
+            insert into column_stats_test values (default);
+
+            insert into column_stats_test
+             select i::smallint,
+                    i::int,
+                    i::bigint,
+                    ('12.' || i)::float4,
+                    ('12.' || i)::float8,
+                    ('12.' || i)::numeric(5,2),
+                    ('12.' || i)::numeric(12,2),
+                    ('12.' || i)::numeric(25,2),
+                    ('12.' || i)::numeric(40,2),
+                    ('12.' || i)::numeric,
+                    ('CrunchyData' || i)::text,
+                    ('CrunchyData' || i)::varchar,
+                    ('01-02-20' || i)::date,
+                    ('01-02-20' || i)::timestamp,
+                    ('01-02-20' || i || ' 00:00:00-03:00')::timestamptz,
+                    ('01:02:' || i % 60)::time,
+                    ('01:02:' || i % 60 || '+03:00')::timetz,
+                    i::oid,
+                    (i % 2 = 0)::bool,
+                    chr(i)::\"char\",
+                    ('\\x0102' || i)::bytea,
+                    ('\\011\\\\\'\'' || encode(chr(i)::bytea, 'escape'))::bytea,
+                    array[i, i + 1, i + 2]::int[],
+                    row(i, 'CrunchyData' || i)::person,
+                    point(i, i + 1)::point,
+                    ('{{\"key\":' || i || '}}')::json,
+                    ('{{\"key\":' || i || '}}')::jsonb,
+                    ('041761f3-d843-49c7-bbd3-c50c86ec34' || i)::uuid
+             from generate_series({series_start}, {series_end}) i;
+
+            -- default are all nulls
+            insert into column_stats_test values (default);
+
+            copy column_stats_test to '{LOCAL_TEST_FILE_PATH}' with (row_group_size {row_group_size});
+        "
+        );
+        Spi::run(&ddls).unwrap();
+
+        let parquet_column_stats_command = format!(
+            "select * from parquet.column_stats('{}') order by field_id;",
+            LOCAL_TEST_FILE_PATH
+        );
+        let result_column_stats = Spi::connect(|client| {
+            let mut results = Vec::new();
+            let tup_table = client
+                .select(&parquet_column_stats_command, None, None)
+                .unwrap();
+
+            for row in tup_table {
+                let field_id = row["field_id"].value::<i32>().unwrap().unwrap();
+                let stats_min = row["stats_min"].value::<String>().unwrap();
+                let stats_max = row["stats_max"].value::<String>().unwrap();
+                let null_count = row["stats_null_count"].value::<i64>().unwrap();
+                let distinct_count = row["stats_distinct_count"].value::<i64>().unwrap();
+
+                results.push((field_id, stats_min, stats_max, null_count, distinct_count));
+            }
+
+            results
+        });
+
+        let expected_column_stats = vec![
+            (0, Some("10".into()), Some("89".into()), Some(2), None),
+            (1, Some("10".into()), Some("89".into()), Some(2), None),
+            (2, Some("10".into()), Some("89".into()), Some(2), None),
+            (3, Some("12.1".into()), Some("12.89".into()), Some(2), None),
+            (4, Some("12.1".into()), Some("12.89".into()), Some(2), None),
+            (5, Some("12.10".into()), Some("12.89".into()), Some(2), None),
+            (6, Some("12.10".into()), Some("12.89".into()), Some(2), None),
+            (7, Some("12.10".into()), Some("12.89".into()), Some(2), None),
+            (8, Some("12.10".into()), Some("12.89".into()), Some(2), None),
+            (
+                9,
+                Some("12.100000000".into()),
+                Some("12.890000000".into()),
+                Some(2),
+                None,
+            ),
+            (
+                10,
+                Some("CrunchyData10".into()),
+                Some("CrunchyData89".into()),
+                Some(2),
+                None,
+            ),
+            (
+                11,
+                Some("CrunchyData10".into()),
+                Some("CrunchyData89".into()),
+                Some(2),
+                None,
+            ),
+            (
+                12,
+                Some("2010-01-02".into()),
+                Some("2089-01-02".into()),
+                Some(2),
+                None,
+            ),
+            (
+                13,
+                Some("2010-01-02 00:00:00".into()),
+                Some("2089-01-02 00:00:00".into()),
+                Some(2),
+                None,
+            ),
+            (
+                14,
+                Some("2010-01-02 05:00:00+02".into()),
+                Some("2089-01-02 06:00:00+03".into()),
+                Some(2),
+                None,
+            ),
+            (
+                15,
+                Some("01:02:00".into()),
+                Some("01:02:59".into()),
+                Some(2),
+                None,
+            ),
+            (
+                16,
+                Some("22:02:00+00".into()),
+                Some("22:02:59+00".into()),
+                Some(2),
+                None,
+            ),
+            (17, Some("10".into()), Some("89".into()), Some(2), None),
+            (18, Some("false".into()), Some("true".into()), Some(2), None),
+            (19, Some("\n".into()), Some("Y".into()), Some(2), None),
+            (
+                20,
+                Some("\\x010210".into()),
+                Some("\\x010289".into()),
+                Some(2),
+                None,
+            ),
+            (
+                21,
+                Some("\\x095C270A".into()),
+                Some("\\x095C2759".into()),
+                Some(2),
+                None,
+            ),
+            (23, Some("10".into()), Some("91".into()), Some(2), None),
+            (25, Some("10".into()), Some("89".into()), Some(2), None),
+            (
+                26,
+                Some("CrunchyData10".into()),
+                Some("CrunchyData89".into()),
+                Some(2),
+                None,
+            ),
+            (
+                27,
+                Some("(10,11)".into()),
+                Some("(89,90)".into()),
+                Some(2),
+                None,
+            ),
+            (
+                28,
+                Some("{\"key\":10}".into()),
+                Some("{\"key\":89}".into()),
+                Some(2),
+                None,
+            ),
+            (
+                29,
+                Some("{\"key\": 10}".into()),
+                Some("{\"key\": 89}".into()),
+                Some(2),
+                None,
+            ),
+            (
+                30,
+                Some("041761f3-d843-49c7-bbd3-c50c86ec3410".into()),
+                Some("041761f3-d843-49c7-bbd3-c50c86ec3489".into()),
+                Some(2),
+                None,
+            ),
+        ];
+
+        assert_eq!(result_column_stats, expected_column_stats);
+
+        Spi::run("DROP TABLE column_stats_test; DROP TYPE person;").unwrap();
+    }
 }


### PR DESCRIPTION
Previously, we printed column statistics for each column per row group via `parquet.metadata(uri)`. With the new udf `parquet.column_stats(uri)`, we print the column stats for each column aggregated by row groups.

Stats for some of the types were printed in a text format that cannot be converted to actual Postgres type. This PR also makes sure the output format is convertible to the actual Postgres type.