### PR TITLE
Support http(s) stores

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -18,5 +18,9 @@ AZURE_TEST_CONTAINER_NAME=testcontainer
 AZURE_TEST_READ_ONLY_SAS="se=2100-05-05&sp=r&sv=2022-11-02&sr=c&sig=YMPFnAHKe9y0o3hFegncbwQTXtAyvsJEgPB2Ne1b9CQ%3D"
 AZURE_TEST_READ_WRITE_SAS="se=2100-05-05&sp=rcw&sv=2022-11-02&sr=c&sig=TPz2jEz0t9L651t6rTCQr%2BOjmJHkM76tnCGdcyttnlA%3D"
 
+# http(s) tests
+ALLOW_HTTP=true
+HTTP_ENDPOINT=http://localhost:8080
+
 # Others
 RUST_TEST_THREADS=1

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     depends_on:
       - minio
       - azurite
+      - webdav
 
   minio:
     image: minio/minio
@@ -44,6 +45,19 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "nc", "-z", "localhost", "10000"]
+      interval: 6s
+      timeout: 2s
+      retries: 3
+
+  webdav:
+    image: rclone/rclone
+    command: ["serve", "webdav", "/data", "--addr", ":8080"]
+    env_file:
+      - .env
+    network_mode: host
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "8080"]
       interval: 6s
       timeout: 2s
       retries: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,18 @@ jobs:
           az storage container create -n $AZURE_TEST_CONTAINER_NAME --connection-string $AZURE_STORAGE_CONNECTION_STRING
           az storage container create -n ${AZURE_TEST_CONTAINER_NAME}2 --connection-string $AZURE_STORAGE_CONNECTION_STRING
 
+      - name: Start local web server for http(s) tests
+        run: |
+          docker run -d \
+            --env-file .devcontainer/.env \
+            -p 8080:80 \
+            rclone/rclone serve webdav /data --addr :80
+
+          while ! curl $HTTP_ENDPOINT; do
+            echo "Waiting for $HTTP_ENDPOINT..."
+            sleep 1
+          done
+
       - name: Run tests
         run: |
           # Run tests with coverage tool

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ aws-credential-types = {version = "1", default-features = false}
 azure_storage = {version = "0.21", default-features = false}
 futures = "0.3"
 home = "0.5"
-object_store = {version = "0.11", default-features = false, features = ["aws", "azure"]}
+object_store = {version = "0.11", default-features = false, features = ["aws", "azure", "http"]}
 once_cell = "1"
 parquet = {version = "54", default-features = false, features = [
     "arrow",

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ SELECT uri, encode(key, 'escape') as key, encode(value, 'escape') as value FROM 
 ```
 
 ## Object Store Support
-`pg_parquet` supports reading and writing Parquet files from/to `S3` and `Azure Blob Storage` object stores.
+`pg_parquet` supports reading and writing Parquet files from/to `S3`, `Azure Blob Storage` and `http(s)` object stores.
 
 > [!NOTE]
 > To be able to write into a object store location, you need to grant `parquet_object_store_write` role to your current postgres user.
@@ -240,6 +240,10 @@ Supported authorization methods' priority order is shown below:
 1. Bearer token via client secret,
 2. Sas token,
 3. Storage key.
+
+#### Http(s) Storage
+
+`Https` uris are supported by default. You can set `ALLOW_HTTP` environment variable to allow `http` uris.
 
 ## Copy Options
 `pg_parquet` supports the following options in the `COPY TO` command:

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -9,5 +9,6 @@ use crate::{
 
 pub(crate) mod aws;
 pub(crate) mod azure;
+pub(crate) mod http;
 pub(crate) mod local_file;
 pub(crate) mod object_store_cache;

--- a/src/object_store/http.rs
+++ b/src/object_store/http.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use object_store::{http::HttpBuilder, ClientOptions};
+use url::Url;
+
+use super::object_store_cache::ObjectStoreWithExpiration;
+
+// create_http_object_store creates a http(s) object store with the given bucket name.
+pub(crate) fn create_http_object_store(uri: &Url) -> ObjectStoreWithExpiration {
+    let base_uri = parse_http_base_uri(uri).unwrap_or_else(|| {
+        panic!("unsupported http uri: {}", uri);
+    });
+
+    let allow_http = std::env::var("ALLOW_HTTP").is_ok();
+
+    let client_options = ClientOptions::new()
+        .with_allow_http2()
+        .with_allow_http(allow_http);
+
+    let http_builder = HttpBuilder::new()
+        .with_url(base_uri)
+        .with_client_options(client_options);
+
+    let object_store = http_builder.build().unwrap_or_else(|e| panic!("{}", e));
+
+    let expire_at = None;
+
+    ObjectStoreWithExpiration {
+        object_store: Arc::new(object_store),
+        expire_at,
+    }
+}
+
+pub(crate) fn parse_http_base_uri(uri: &Url) -> Option<String> {
+    let scheme = uri.scheme();
+
+    let host = uri.host_str().expect("http uri missing host");
+
+    let port = uri.port().map(|p| format!(":{}", p)).unwrap_or_default();
+
+    Some(format!("{}://{}{}", scheme, host, port))
+}

--- a/src/object_store/object_store_cache.rs
+++ b/src/object_store/object_store_cache.rs
@@ -12,7 +12,10 @@ use url::Url;
 
 use crate::arrow_parquet::uri_utils::ParsedUriInfo;
 
-use super::{create_azure_object_store, create_local_file_object_store, create_s3_object_store};
+use super::{
+    create_azure_object_store, create_local_file_object_store, create_s3_object_store,
+    http::create_http_object_store,
+};
 
 // OBJECT_STORE_CACHE is a global cache for object stores per Postgres session.
 // It caches object stores based on the scheme and bucket.
@@ -86,9 +89,10 @@ impl ObjectStoreCache {
         match scheme {
             ObjectStoreScheme::AmazonS3 => create_s3_object_store(uri),
             ObjectStoreScheme::MicrosoftAzure => create_azure_object_store(uri),
+            ObjectStoreScheme::Http => create_http_object_store(uri),
             ObjectStoreScheme::Local => create_local_file_object_store(uri, copy_from),
             _ => panic!(
-                    "unsupported scheme {} in uri {}. pg_parquet supports local paths, s3:// or azure:// schemes.",
+                    "unsupported scheme {} in uri {}. pg_parquet supports local paths, https, s3:// or az:// schemes.",
                     uri.scheme(),
                     uri
                 ),


### PR DESCRIPTION
pg_parquet supports reading/writing from/to public http(s) parquet uris to/from Postgres tables.

Closes #108.