### PR TITLE
Support copying from glob patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,6 +2527,7 @@ dependencies = [
  "azure_storage",
  "cfg_aliases",
  "futures",
+ "glob",
  "home",
  "libc",
  "object_store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ aws-config = { version = "1", default-features = false, features = ["rustls","rt
 aws-credential-types = {version = "1", default-features = false}
 azure_storage = {version = "0.21", default-features = false}
 futures = "0.3"
+glob = "0.3"
 home = "0.5"
 libc = {version = "0.2", default-features = false }
 object_store = {version = "=0.12.2", default-features = false, features = ["aws", "azure", "fs", "gcp", "http"]}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ COPY table FROM 's3://mybucket/data.parquet' WITH (format 'parquet');
   - [Inspect Parquet schema](#inspect-parquet-schema)
   - [Inspect Parquet metadata](#inspect-parquet-metadata)
   - [Inspect Parquet column statistics](#inspect-parquet-column-statistics)
+  - [List and read Parquet files from uri pattern](#list-and-read-parquet-files-from-uri-pattern)
 - [Object Store Support](#object-store-support)
 - [Copy Options](#copy-options)
 - [Configuration](#configuration)
@@ -217,6 +218,40 @@ SELECT * FROM parquet.column_stats('/tmp/product_example.parquet')
 (13 rows)
 ```
 
+### List and read Parquet files from uri pattern
+
+You can call `SELECT * FROM parquet.list(<uri_pattern>)` to see all uris that matches with the uri pattern.
+Uri pattern can resolve `**` for directories and `*` for words in the uri.
+
+
+```sql
+COPY (SELECT i FROM generate_series(1, 1000000) i) TO '/tmp/some/test.parquet' with (file_size_bytes '1MB');
+COPY 1000000
+
+SELECT * FROM parquet.list('/tmp/some/**/*.parquet');
+                  uri                  |  size
+---------------------------------------+---------
+ /tmp/some/test.parquet/data_4.parquet |  100162
+ /tmp/some/test.parquet/data_3.parquet | 1486916
+ /tmp/some/test.parquet/data_2.parquet | 1486916
+ /tmp/some/test.parquet/data_0.parquet | 1486920
+ /tmp/some/test.parquet/data_1.parquet | 1486916
+(5 rows)
+
+```
+
+Uri pattern is also supported by `COPY FROM` for all supported object stores except `http(s)` endpoints.
+```sql
+COPY (SELECT i FROM generate_series(1, 1000000) i) TO 's3://testbucket/some/test.parquet' with (file_size_bytes '1MB');
+COPY 1000000
+
+CREATE TABLE test(a int);
+CREATE TABLE
+
+COPY test FROM 's3://testbucket/some/**/*.parquet';
+COPY 1000000
+```
+
 ## Object Store Support
 `pg_parquet` supports reading and writing Parquet files from/to `S3`, `Azure Blob Storage`, `http(s)` and `Google Cloud Storage` object stores.
 
@@ -304,7 +339,7 @@ Supported authorization methods' priority order is shown below:
 
 #### Http(s) Storage
 
-`Https` uris are supported by default. You can set `ALLOW_HTTP` environment variable to allow `http` uris.
+Only `https` uris are supported by default. You can set `ALLOW_HTTP` environment variable to allow `http` uris.
 
 #### Google Cloud Storage
 

--- a/src/arrow_parquet/parquet_reader.rs
+++ b/src/arrow_parquet/parquet_reader.rs
@@ -1,7 +1,11 @@
-use std::sync::Arc;
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use arrow::array::RecordBatch;
 use arrow_cast::{cast_with_options, CastOptions};
+use arrow_schema::SchemaRef;
 use futures::StreamExt;
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStream};
 use pgrx::{
@@ -23,6 +27,7 @@ use crate::{
             parquet_schema_string_from_attributes,
         },
     },
+    parquet_udfs::list::list_uri,
     pgrx_utils::{collect_attributes_for, CollectAttributesFor},
     type_compat::{geometry::reset_postgis_context, map::reset_map_context},
     PG_BACKEND_TOKIO_RUNTIME,
@@ -37,113 +42,93 @@ use super::{
     uri_utils::{parquet_reader_from_uri, ParsedUriInfo},
 };
 
-pub(crate) struct ParquetReaderContext {
-    buffer: Vec<u8>,
-    offset: usize,
-    started: bool,
-    finished: bool,
-    parquet_reader: ParquetRecordBatchStream<ParquetObjectReader>,
+pub(crate) struct SingleParquetReader {
+    reader: ParquetRecordBatchStream<ParquetObjectReader>,
     attribute_contexts: Vec<ArrowToPgAttributeContext>,
-    binary_out_funcs: Vec<PgBox<FmgrInfo>>,
     match_by: MatchBy,
-    per_row_memory_ctx: PgMemoryContexts,
 }
 
-impl ParquetReaderContext {
-    pub(crate) fn new(
+impl Deref for SingleParquetReader {
+    type Target = ParquetRecordBatchStream<ParquetObjectReader>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.reader
+    }
+}
+
+impl DerefMut for SingleParquetReader {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.reader
+    }
+}
+
+impl SingleParquetReader {
+    fn new(
         uri_info: &ParsedUriInfo,
         match_by: MatchBy,
-        tupledesc: &PgTupleDesc,
+        tupledesc_schema: SchemaRef,
+        attributes: &[FormData_pg_attribute],
     ) -> Self {
-        // Postgis and Map contexts are used throughout reading the parquet file.
-        // We need to reset them to avoid reading the stale data. (e.g. extension could be dropped)
-        reset_postgis_context();
-        reset_map_context();
-
-        error_if_copy_from_match_by_position_with_generated_columns(tupledesc, match_by);
-
-        let parquet_reader = parquet_reader_from_uri(uri_info);
-
-        let parquet_file_schema = parquet_reader.schema();
-
-        let attributes = collect_attributes_for(CollectAttributesFor::CopyFrom, tupledesc);
-
-        pgrx::debug2!(
-            "schema for tuples: {}",
-            parquet_schema_string_from_attributes(&attributes, FieldIds::None)
-        );
-
-        let tupledesc_schema = parse_arrow_schema_from_attributes(&attributes, FieldIds::None);
-
-        let tupledesc_schema = Arc::new(tupledesc_schema);
+        let reader = parquet_reader_from_uri(uri_info);
 
         // Ensure that the file schema matches the tupledesc schema.
         // Gets cast_to_types for each attribute if a cast is needed for the attribute's columnar array
         // to match the expected columnar array for its tupledesc type.
         let cast_to_types = ensure_file_schema_match_tupledesc_schema(
-            parquet_file_schema.clone(),
+            reader.schema().clone(),
             tupledesc_schema.clone(),
-            &attributes,
+            attributes,
             match_by,
         );
 
         let attribute_contexts = collect_arrow_to_pg_attribute_contexts(
-            &attributes,
+            attributes,
             &tupledesc_schema.fields,
             Some(cast_to_types),
         );
 
-        let binary_out_funcs = Self::collect_binary_out_funcs(&attributes);
-
-        let per_row_memory_ctx = PgMemoryContexts::new("COPY FROM parquet per row memory context");
-
-        ParquetReaderContext {
-            buffer: Vec::new(),
-            offset: 0,
+        SingleParquetReader {
+            reader,
             attribute_contexts,
-            parquet_reader,
-            binary_out_funcs,
             match_by,
-            started: false,
-            finished: false,
-            per_row_memory_ctx,
         }
     }
 
-    fn collect_binary_out_funcs(
-        attributes: &[FormData_pg_attribute],
-    ) -> Vec<PgBox<FmgrInfo, AllocatedByPostgres>> {
-        unsafe {
-            let mut binary_out_funcs = vec![];
-
-            for att in attributes.iter() {
-                let typoid = att.type_oid();
-
-                let mut send_func_oid = InvalidOid;
-                let mut is_varlena = false;
-                getTypeBinaryOutputInfo(typoid.value(), &mut send_func_oid, &mut is_varlena);
-
-                let arg_fninfo = PgBox::<FmgrInfo>::alloc0().into_pg_boxed();
-                fmgr_info(send_func_oid, arg_fninfo.as_ptr());
-
-                binary_out_funcs.push(arg_fninfo);
-            }
-
-            binary_out_funcs
-        }
-    }
-
-    fn record_batch_to_tuple_datums(
-        record_batch: RecordBatch,
-        attribute_contexts: &[ArrowToPgAttributeContext],
+    fn create_readers_from_pattern_uri(
+        uri_info: &ParsedUriInfo,
         match_by: MatchBy,
-    ) -> Vec<Option<Datum>> {
+        tupledesc_schema: SchemaRef,
+        attributes: &[FormData_pg_attribute],
+    ) -> Vec<Self> {
+        debug_assert!(uri_info.is_pattern());
+
+        list_uri(uri_info)
+            .into_iter()
+            .map(|(file_uri, _)| {
+                let file_uri_info = ParsedUriInfo::try_from(file_uri.as_str())
+                    .unwrap_or_else(|e| panic!("failed to parse file uri {}: {}", file_uri, e));
+
+                SingleParquetReader::new(
+                    &file_uri_info,
+                    match_by,
+                    tupledesc_schema.clone(),
+                    attributes,
+                )
+            })
+            .collect()
+    }
+
+    fn attribute_count(&self) -> usize {
+        self.attribute_contexts.len()
+    }
+
+    fn record_batch_to_tuple_datums(&self, record_batch: RecordBatch) -> Vec<Option<Datum>> {
         let mut datums = vec![];
 
-        for (attribute_idx, attribute_context) in attribute_contexts.iter().enumerate() {
+        for (attribute_idx, attribute_context) in self.attribute_contexts.iter().enumerate() {
             let name = attribute_context.name();
 
-            let column_array = match match_by {
+            let column_array = match self.match_by {
                 MatchBy::Position => record_batch
                     .columns()
                     .get(attribute_idx)
@@ -175,6 +160,110 @@ impl ParquetReaderContext {
 
         datums
     }
+}
+
+pub(crate) struct ParquetReaderContext {
+    buffer: Vec<u8>,
+    offset: usize,
+    started: bool,
+    finished: bool,
+    parquet_readers: Vec<SingleParquetReader>,
+    current_parquet_reader_idx: usize,
+    binary_out_funcs: Vec<PgBox<FmgrInfo>>,
+    per_row_memory_ctx: PgMemoryContexts,
+}
+
+impl ParquetReaderContext {
+    pub(crate) fn new(
+        uri_info: &ParsedUriInfo,
+        match_by: MatchBy,
+        tupledesc: &PgTupleDesc,
+    ) -> Self {
+        // Postgis and Map contexts are used throughout reading the parquet file.
+        // We need to reset them to avoid reading the stale data. (e.g. extension could be dropped)
+        reset_postgis_context();
+        reset_map_context();
+
+        error_if_copy_from_match_by_position_with_generated_columns(tupledesc, match_by);
+
+        let attributes = collect_attributes_for(CollectAttributesFor::CopyFrom, tupledesc);
+
+        pgrx::debug2!(
+            "schema for tuples: {}",
+            parquet_schema_string_from_attributes(&attributes, FieldIds::None)
+        );
+
+        let tupledesc_schema = parse_arrow_schema_from_attributes(&attributes, FieldIds::None);
+
+        let tupledesc_schema = Arc::new(tupledesc_schema);
+
+        let parquet_readers = if uri_info.is_pattern() {
+            SingleParquetReader::create_readers_from_pattern_uri(
+                uri_info,
+                match_by,
+                tupledesc_schema,
+                &attributes,
+            )
+        } else {
+            vec![SingleParquetReader::new(
+                uri_info,
+                match_by,
+                tupledesc_schema.clone(),
+                &attributes,
+            )]
+        };
+
+        if parquet_readers.is_empty() {
+            panic!("no files found that match the pattern {}", uri_info.path);
+        }
+
+        let binary_out_funcs = Self::collect_binary_out_funcs(&attributes);
+
+        let per_row_memory_ctx = PgMemoryContexts::new("COPY FROM parquet per row memory context");
+
+        ParquetReaderContext {
+            buffer: Vec::new(),
+            offset: 0,
+            parquet_readers,
+            current_parquet_reader_idx: 0,
+            binary_out_funcs,
+            started: false,
+            finished: false,
+            per_row_memory_ctx,
+        }
+    }
+
+    fn current_reader(&self) -> Option<&SingleParquetReader> {
+        self.parquet_readers.get(self.current_parquet_reader_idx)
+    }
+
+    fn current_reader_mut(&mut self) -> Option<&mut SingleParquetReader> {
+        self.parquet_readers
+            .get_mut(self.current_parquet_reader_idx)
+    }
+
+    fn collect_binary_out_funcs(
+        attributes: &[FormData_pg_attribute],
+    ) -> Vec<PgBox<FmgrInfo, AllocatedByPostgres>> {
+        unsafe {
+            let mut binary_out_funcs = vec![];
+
+            for att in attributes.iter() {
+                let typoid = att.type_oid();
+
+                let mut send_func_oid = InvalidOid;
+                let mut is_varlena = false;
+                getTypeBinaryOutputInfo(typoid.value(), &mut send_func_oid, &mut is_varlena);
+
+                let arg_fninfo = PgBox::<FmgrInfo>::alloc0().into_pg_boxed();
+                fmgr_info(send_func_oid, arg_fninfo.as_ptr());
+
+                binary_out_funcs.push(arg_fninfo);
+            }
+
+            binary_out_funcs
+        }
+    }
 
     pub(crate) fn read_parquet(&mut self) -> bool {
         if self.finished {
@@ -188,7 +277,8 @@ impl ParquetReaderContext {
 
         // read a record batch from the parquet file. Record batch will contain
         // DEFAULT_BATCH_SIZE rows as we configured in the parquet reader.
-        let record_batch = PG_BACKEND_TOKIO_RUNTIME.block_on(self.parquet_reader.next());
+        let record_batch = PG_BACKEND_TOKIO_RUNTIME
+            .block_on(self.current_reader_mut().expect("no reader found").next());
 
         if let Some(batch_result) = record_batch {
             let record_batch =
@@ -201,8 +291,23 @@ impl ParquetReaderContext {
 
                 // slice the record batch to get the next row
                 let record_batch = record_batch.slice(i, 1);
-                self.copy_row(record_batch);
+
+                let natts = self
+                    .current_reader()
+                    .expect("no reader found")
+                    .attribute_count() as i16;
+
+                let tuple_datums = self
+                    .current_reader()
+                    .expect("no reader found")
+                    .record_batch_to_tuple_datums(record_batch);
+
+                self.copy_row(natts, tuple_datums);
             }
+        } else if self.current_parquet_reader_idx + 1 < self.parquet_readers.len() {
+            // move to the next parquet reader
+            self.current_parquet_reader_idx += 1;
+            self.read_parquet();
         } else {
             // finish PG copy
             self.copy_finish();
@@ -211,45 +316,37 @@ impl ParquetReaderContext {
         true
     }
 
-    fn copy_row(&mut self, record_batch: RecordBatch) {
+    fn copy_row(&mut self, natts: i16, tuple_datums: Vec<Option<Datum>>) {
         unsafe {
-            self.per_row_memory_ctx.switch_to(|_context| {
-                /* 2 bytes: per-tuple header */
-                let natts = self.attribute_contexts.len() as i16;
-                let attnum_len_bytes = natts.to_be_bytes();
-                self.buffer.extend_from_slice(&attnum_len_bytes);
+            let mut old_ctx = self.per_row_memory_ctx.set_as_current();
 
-                // convert the columnar arrays in record batch to tuple datums
-                let tuple_datums = Self::record_batch_to_tuple_datums(
-                    record_batch,
-                    &self.attribute_contexts,
-                    self.match_by,
-                );
+            /* 2 bytes: per-tuple header */
+            let attnum_len_bytes = natts.to_be_bytes();
+            self.buffer.extend_from_slice(&attnum_len_bytes);
 
-                // write the tuple datums to the ParquetReader's internal buffer in PG copy format
-                for (datum, out_func) in tuple_datums.into_iter().zip(self.binary_out_funcs.iter())
-                {
-                    if let Some(datum) = datum {
-                        let datum_bytes: *mut varlena = SendFunctionCall(out_func.as_ptr(), datum);
+            // write the tuple datums to the ParquetReader's internal buffer in PG copy format
+            for (datum, out_func) in tuple_datums.into_iter().zip(self.binary_out_funcs.iter()) {
+                if let Some(datum) = datum {
+                    let datum_bytes: *mut varlena = SendFunctionCall(out_func.as_ptr(), datum);
 
-                        /* 4 bytes: attribute's data size */
-                        let data_size = varsize_any_exhdr(datum_bytes);
-                        let data_size_bytes = (data_size as i32).to_be_bytes();
-                        self.buffer.extend_from_slice(&data_size_bytes);
+                    /* 4 bytes: attribute's data size */
+                    let data_size = varsize_any_exhdr(datum_bytes);
+                    let data_size_bytes = (data_size as i32).to_be_bytes();
+                    self.buffer.extend_from_slice(&data_size_bytes);
 
-                        /* variable bytes: attribute's data */
-                        let data = vardata_any(datum_bytes) as _;
-                        let data_bytes = std::slice::from_raw_parts(data, data_size);
-                        self.buffer.extend_from_slice(data_bytes);
-                    } else {
-                        /* 4 bytes: null */
-                        let null_value = -1_i32;
-                        let null_value_bytes = null_value.to_be_bytes();
-                        self.buffer.extend_from_slice(&null_value_bytes);
-                    }
+                    /* variable bytes: attribute's data */
+                    let data = vardata_any(datum_bytes) as _;
+                    let data_bytes = std::slice::from_raw_parts(data, data_size);
+                    self.buffer.extend_from_slice(data_bytes);
+                } else {
+                    /* 4 bytes: null */
+                    let null_value = -1_i32;
+                    let null_value_bytes = null_value.to_be_bytes();
+                    self.buffer.extend_from_slice(&null_value_bytes);
                 }
-            });
+            }
 
+            old_ctx.set_as_current();
             self.per_row_memory_ctx.reset();
         };
     }

--- a/src/arrow_parquet/uri_utils.rs
+++ b/src/arrow_parquet/uri_utils.rs
@@ -151,6 +151,10 @@ impl ParsedUriInfo {
                             uri.scheme(), uri))
         }
     }
+
+    pub(crate) fn is_pattern(&self) -> bool {
+        self.path.to_string().contains('*') || self.path.to_string().contains("**")
+    }
 }
 
 impl TryFrom<&str> for ParsedUriInfo {
@@ -200,6 +204,21 @@ pub(crate) fn uri_as_string(uri: &Url) -> String {
     }
 
     uri.to_string()
+}
+
+pub(crate) fn object_store_base_uri(uri: &Url) -> String {
+    if uri.scheme() == "file" {
+        // root path for local file
+        return "/".to_string();
+    }
+
+    let scheme = uri.scheme();
+
+    let host = uri.host_str().expect("missing host in uri");
+
+    let port = uri.port().map(|p| format!(":{}", p)).unwrap_or_default();
+
+    format!("{}://{}{}", scheme, host, port)
 }
 
 pub(crate) fn parquet_schema_from_uri(uri_info: &ParsedUriInfo) -> SchemaDescriptor {

--- a/src/object_store/http.rs
+++ b/src/object_store/http.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use object_store::{http::HttpBuilder, ClientOptions};
 use url::Url;
 
+use crate::arrow_parquet::uri_utils::object_store_base_uri;
+
 use super::object_store_cache::ObjectStoreWithExpiration;
 
 // create_http_object_store creates a http(s) object store with the given bucket name.
@@ -32,11 +34,5 @@ pub(crate) fn create_http_object_store(uri: &Url) -> ObjectStoreWithExpiration {
 }
 
 pub(crate) fn parse_http_base_uri(uri: &Url) -> Option<String> {
-    let scheme = uri.scheme();
-
-    let host = uri.host_str().expect("http uri missing host");
-
-    let port = uri.port().map(|p| format!(":{p}")).unwrap_or_default();
-
-    Some(format!("{scheme}://{host}{port}"))
+    Some(object_store_base_uri(uri))
 }

--- a/src/object_store/local_file.rs
+++ b/src/object_store/local_file.rs
@@ -12,9 +12,9 @@ pub(crate) fn create_local_file_object_store(
     uri: &Url,
     copy_from: bool,
 ) -> ObjectStoreWithExpiration {
-    let path = uri_as_string(uri);
-
     if !copy_from {
+        let path = uri_as_string(uri);
+
         // create parent folder if it doesn't exist
         let parent = std::path::Path::new(&path)
             .parent()

--- a/src/parquet_udfs.rs
+++ b/src/parquet_udfs.rs
@@ -1,3 +1,4 @@
+pub(crate) mod list;
 pub(crate) mod metadata;
 pub(crate) mod schema;
 pub(crate) mod stats;

--- a/src/parquet_udfs/list.rs
+++ b/src/parquet_udfs/list.rs
@@ -43,10 +43,10 @@ pub(crate) fn list_uri(uri_info: &ParsedUriInfo) -> Vec<(String, i64)> {
         panic!("{}", e);
     });
 
-    // prefix is the part of the location that doesn't contain any wildcards
+    // prefix is the part of the location that doesn't contain any patterns
     let prefix = location
         .parts()
-        .take_while(|part| !part.as_ref().contains("*") && !part.as_ref().contains("**"))
+        .take_while(|part| !part.as_ref().contains('*'))
         .collect();
 
     // Collect all paths from the list stream

--- a/src/parquet_udfs/list.rs
+++ b/src/parquet_udfs/list.rs
@@ -1,0 +1,92 @@
+use futures::StreamExt;
+use glob::{MatchOptions, Pattern};
+use pgrx::{iter::TableIterator, name, pg_extern, pg_schema};
+
+use crate::arrow_parquet::uri_utils::{
+    ensure_access_privilege_to_uri, object_store_base_uri, ParsedUriInfo,
+};
+use crate::object_store::object_store_cache::get_or_create_object_store;
+use crate::PG_BACKEND_TOKIO_RUNTIME;
+
+#[pg_schema]
+mod parquet {
+    use super::*;
+
+    #[pg_extern]
+    fn list(uri: String) -> TableIterator<'static, (name!(uri, String), name!(size, i64))> {
+        let uri_info = ParsedUriInfo::try_from(uri.as_str()).unwrap_or_else(|e| {
+            panic!("{}", e.to_string());
+        });
+
+        TableIterator::new(list_uri(&uri_info))
+    }
+}
+
+fn error_if_list_http_store(uri_info: &ParsedUriInfo) {
+    if uri_info.uri.scheme() == "http" || uri_info.uri.scheme() == "https" {
+        panic!("list operation on http(s) object stores is not supported");
+    }
+}
+
+pub(crate) fn list_uri(uri_info: &ParsedUriInfo) -> Vec<(String, i64)> {
+    ensure_access_privilege_to_uri(uri_info, true);
+
+    error_if_list_http_store(uri_info);
+
+    let base_uri = object_store_base_uri(&uri_info.uri);
+
+    let copy_from = true;
+    let (parquet_object_store, location) = get_or_create_object_store(uri_info, copy_from);
+
+    // build the pattern before we start the stream to bail out early
+    let pattern = Pattern::new(location.as_ref()).unwrap_or_else(|e| {
+        panic!("{}", e);
+    });
+
+    // prefix is the part of the location that doesn't contain any wildcards
+    let prefix = location
+        .parts()
+        .take_while(|part| !part.as_ref().contains("*") && !part.as_ref().contains("**"))
+        .collect();
+
+    // Collect all paths from the list stream
+    let mut list_stream = parquet_object_store.list(Some(&prefix));
+
+    let mut paths = vec![];
+
+    PG_BACKEND_TOKIO_RUNTIME.block_on(async {
+        while let Some(meta) = list_stream.next().await.transpose().unwrap_or_else(|e| {
+            panic!("{}", e);
+        }) {
+            let path = meta.location.to_string();
+            let size = meta.size as _;
+
+            paths.push((path, size));
+        }
+    });
+
+    // Filter out uris that don't match the pattern
+    paths
+        .into_iter()
+        .filter(|(path, _)| {
+            pattern.matches_path_with(
+                std::path::Path::new(path),
+                MatchOptions {
+                    case_sensitive: true,
+                    require_literal_separator: true,
+                    require_literal_leading_dot: false,
+                },
+            )
+        })
+        .map(|(path, size)| {
+            (
+                std::path::Path::new(&base_uri)
+                    .join(path)
+                    .to_str()
+                    .expect("invalid list uri path")
+                    .to_string(),
+                size,
+            )
+        })
+        .collect::<Vec<_>>()
+}

--- a/src/pgrx_tests/copy_pattern.rs
+++ b/src/pgrx_tests/copy_pattern.rs
@@ -17,7 +17,28 @@ mod tests {
         Spi::run(create_table).unwrap();
 
         let file_pattern = "/tmp/pg_parquet_test/*";
-        let copy_from_command = format!("COPY test_table FROM '{}';", file_pattern);
+        let copy_from_command = format!(
+            "COPY test_table FROM '{}' WITH (format parquet);",
+            file_pattern
+        );
         Spi::run(copy_from_command.as_str()).unwrap();
+    }
+
+    #[pg_test]
+    fn test_pattern_with_special_parquet_file_name() {
+        let filename = "/tmp/pg_parquet_test/du**mm*y1.parquet";
+        let copy_to_parquet =
+            format!("copy (select 1 as a) to '{filename}' with (format parquet);");
+        Spi::run(&copy_to_parquet).unwrap();
+
+        let create_table = "create table test_table(a int);";
+        Spi::run(create_table).unwrap();
+
+        let copy_from_parquet = format!("COPY test_table FROM '{filename}' WITH (format parquet);");
+        Spi::run(copy_from_parquet.as_str()).unwrap();
+
+        let count_query = "select count(*) from test_table;";
+        let result = Spi::get_one::<i64>(count_query).unwrap().unwrap();
+        assert_eq!(result, 1);
     }
 }

--- a/src/pgrx_tests/copy_pattern.rs
+++ b/src/pgrx_tests/copy_pattern.rs
@@ -2,16 +2,22 @@
 mod tests {
     use pgrx::{pg_test, Spi};
 
+    use crate::pgrx_tests::common::FileCleanup;
+
     #[pg_test]
     #[should_panic(expected = "EOF: file size of 2 is less than footer")]
-    fn test_pattern_invalid_parquet_file() {
-        let copy_to_parquet =
-            "copy (select 1 as a) to '/tmp/pg_parquet_test/dummy1.parquet' with (format parquet);";
-        Spi::run(copy_to_parquet).unwrap();
+    fn test_non_parquet_path_in_pattern() {
+        let filename1 = "/tmp/pg_parquet_test/dummy1.parquet";
+        let filename2 = "/tmp/pg_parquet_test/dummy2.csv";
+        let _file1 = FileCleanup::new(filename1);
+        let _file2 = FileCleanup::new(filename2);
 
-        let copy_to_csv =
-            "copy (select 1 as a) to '/tmp/pg_parquet_test/dummy2.csv' with (format csv);";
-        Spi::run(copy_to_csv).unwrap();
+        let copy_to_parquet =
+            format!("copy (select 1 as a) to '{filename1}' with (format parquet);");
+        Spi::run(&copy_to_parquet).unwrap();
+
+        let copy_to_csv = format!("copy (select 1 as a) to '{filename2}' with (format csv);");
+        Spi::run(&copy_to_csv).unwrap();
 
         let create_table = "create table test_table(a int);";
         Spi::run(create_table).unwrap();
@@ -25,8 +31,10 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_pattern_with_special_parquet_file_name() {
+    fn test_path_with_special_parquet_file_name() {
         let filename = "/tmp/pg_parquet_test/du**mm*y1.parquet";
+        let _file = FileCleanup::new(filename);
+
         let copy_to_parquet =
             format!("copy (select 1 as a) to '{filename}' with (format parquet);");
         Spi::run(&copy_to_parquet).unwrap();
@@ -40,5 +48,31 @@ mod tests {
         let count_query = "select count(*) from test_table;";
         let result = Spi::get_one::<i64>(count_query).unwrap().unwrap();
         assert_eq!(result, 1);
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "failed to get object store metadata")]
+    fn test_path_with_special_chars() {
+        let filename = "/tmp/pg_parquet_test/du**\\mm*y1.parquet";
+        let _file = FileCleanup::new(filename);
+
+        let create_table = "create table test_table(a int);";
+        Spi::run(create_table).unwrap();
+
+        let copy_from_parquet = format!("COPY test_table FROM '{filename}' WITH (format parquet);");
+        Spi::run(copy_from_parquet.as_str()).unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "no files found that match the pattern")]
+    fn test_with_nonexistent_pattern_path() {
+        let filename = "/tmp/pg_parquet_test/**";
+        let _file = FileCleanup::new(filename);
+
+        let create_table = "create table test_table(a int);";
+        Spi::run(create_table).unwrap();
+
+        let copy_from_parquet = format!("COPY test_table FROM '{filename}' WITH (format parquet);");
+        Spi::run(copy_from_parquet.as_str()).unwrap();
     }
 }

--- a/src/pgrx_tests/copy_pattern.rs
+++ b/src/pgrx_tests/copy_pattern.rs
@@ -1,0 +1,23 @@
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::{pg_test, Spi};
+
+    #[pg_test]
+    #[should_panic(expected = "EOF: file size of 2 is less than footer")]
+    fn test_pattern_invalid_parquet_file() {
+        let copy_to_parquet =
+            "copy (select 1 as a) to '/tmp/pg_parquet_test/dummy1.parquet' with (format parquet);";
+        Spi::run(copy_to_parquet).unwrap();
+
+        let copy_to_csv =
+            "copy (select 1 as a) to '/tmp/pg_parquet_test/dummy2.csv' with (format csv);";
+        Spi::run(copy_to_csv).unwrap();
+
+        let create_table = "create table test_table(a int);";
+        Spi::run(create_table).unwrap();
+
+        let file_pattern = "/tmp/pg_parquet_test/*";
+        let copy_from_command = format!("COPY test_table FROM '{}';", file_pattern);
+        Spi::run(copy_from_command.as_str()).unwrap();
+    }
+}

--- a/src/pgrx_tests/mod.rs
+++ b/src/pgrx_tests/mod.rs
@@ -1,6 +1,7 @@
 mod common;
 mod copy_from_coerce;
 mod copy_options;
+mod copy_pattern;
 mod copy_pg_rules;
 mod copy_program;
 mod copy_stdin_out;

--- a/src/pgrx_tests/object_store.rs
+++ b/src/pgrx_tests/object_store.rs
@@ -1,10 +1,10 @@
 #[pgrx::pg_schema]
 mod tests {
-    use std::io::Write;
+    use std::{collections::HashMap, io::Write};
 
     use pgrx::{pg_sys::Timestamp, pg_test, Spi};
 
-    use crate::pgrx_tests::common::TestTable;
+    use crate::pgrx_tests::common::{CopyOptionValue, TestTable};
 
     fn object_store_cache_clear() {
         Spi::run("SELECT parquet_test.object_store_cache_clear();").unwrap();
@@ -59,6 +59,36 @@ mod tests {
             test_table.insert("INSERT INTO test_expected (a) VALUES (1), (2), (null);");
             test_table.assert_expected_and_result_rows();
         }
+    }
+
+    #[pg_test]
+    fn test_s3_from_env_glob_pattern() {
+        object_store_cache_clear();
+
+        let test_bucket_name: String =
+            std::env::var("AWS_S3_TEST_BUCKET").expect("AWS_S3_TEST_BUCKET not found");
+
+        let s3_uri = format!(
+            "s3://{test_bucket_name}/test_s3_from_env_glob_pattern/some/pg_parquet_test.parquet"
+        );
+        let s3_uri_pattern =
+            format!("s3://{test_bucket_name}/test_s3_from_env_glob_pattern/**/*.parquet");
+
+        let mut copy_options = HashMap::new();
+        copy_options.insert(
+            "file_size_bytes".to_string(),
+            CopyOptionValue::StringOption("1MB".to_string()),
+        );
+
+        let test_table = TestTable::<i32>::new("int4".into())
+            .with_uri(s3_uri)
+            .with_uri_pattern(s3_uri_pattern)
+            .with_order_by_col("a".into())
+            .with_copy_to_options(copy_options);
+
+        test_table
+            .insert("INSERT INTO test_expected (a) select i from generate_series(1, 1000000) i;");
+        test_table.assert_expected_and_result_rows();
     }
 
     #[pg_test]
@@ -341,6 +371,66 @@ mod tests {
     }
 
     #[pg_test]
+    #[should_panic(expected = "no files found that match the pattern")]
+    fn test_s3_empty_pattern() {
+        object_store_cache_clear();
+
+        let test_bucket_name: String =
+            std::env::var("AWS_S3_TEST_BUCKET").expect("AWS_S3_TEST_BUCKET not found");
+
+        let create_table = "create table test_table(id int);";
+        Spi::run(create_table).unwrap();
+
+        let s3_uri_pattern = format!("s3://{test_bucket_name}/dummy*.parquet");
+        let copy_from_command = format!("COPY test_table FROM '{}';", s3_uri_pattern);
+        Spi::run(copy_from_command.as_str()).unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "column count mismatch")]
+    fn test_s3_pattern_schema_mismatch() {
+        object_store_cache_clear();
+
+        let test_bucket_name: String =
+            std::env::var("AWS_S3_TEST_BUCKET").expect("AWS_S3_TEST_BUCKET not found");
+
+        let copy_to_schema1 = format!("copy (select 1 as a) to 's3://{test_bucket_name}/dummy1.parquet' with (format parquet);");
+        Spi::run(copy_to_schema1.as_str()).unwrap();
+
+        let copy_to_schema2 = format!("copy (select 1 as a, 'asd' as b) to 's3://{test_bucket_name}/dummy2.parquet' with (format parquet);");
+        Spi::run(copy_to_schema2.as_str()).unwrap();
+
+        let create_table = "create table test_table(id int);";
+        Spi::run(create_table).unwrap();
+
+        let s3_uri_pattern = format!("s3://{test_bucket_name}/dummy*.parquet");
+        let copy_from_command = format!("COPY test_table FROM '{}';", s3_uri_pattern);
+        Spi::run(copy_from_command.as_str()).unwrap();
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "type mismatch")]
+    fn test_s3_pattern_column_type_mismatch() {
+        object_store_cache_clear();
+
+        let test_bucket_name: String =
+            std::env::var("AWS_S3_TEST_BUCKET").expect("AWS_S3_TEST_BUCKET not found");
+
+        let copy_to_schema1 = format!("copy (select '{{}}'::jsonb as a) to 's3://{test_bucket_name}/dummy2.parquet' with (format parquet);");
+        Spi::run(copy_to_schema1.as_str()).unwrap();
+
+        let copy_to_schema2 = format!("copy (select 1 as a) to 's3://{test_bucket_name}/dummy1.parquet' with (format parquet);");
+        Spi::run(copy_to_schema2.as_str()).unwrap();
+
+        let create_table = "create table test_table(a jsonb);";
+        Spi::run(create_table).unwrap();
+
+        let s3_uri_pattern = format!("s3://{test_bucket_name}/dummy*.parquet");
+        let copy_from_command = format!("COPY test_table FROM '{}';", s3_uri_pattern);
+        Spi::run(copy_from_command.as_str()).unwrap();
+    }
+
+    #[pg_test]
     #[cfg(not(rhel8))]
     fn test_azure_blob_from_env() {
         object_store_cache_clear();
@@ -366,6 +456,39 @@ mod tests {
             test_table.insert("INSERT INTO test_expected (a) VALUES (1), (2), (null);");
             test_table.assert_expected_and_result_rows();
         }
+    }
+
+    #[pg_test]
+    #[cfg(not(rhel8))]
+    fn test_azure_blob_from_env_glob_pattern() {
+        object_store_cache_clear();
+
+        // unset AZURE_STORAGE_CONNECTION_STRING to make sure the account name and key are used
+        std::env::remove_var("AZURE_STORAGE_CONNECTION_STRING");
+
+        let test_container_name: String = std::env::var("AZURE_TEST_CONTAINER_NAME")
+            .expect("AZURE_TEST_CONTAINER_NAME not found");
+
+        let azure_blob_uri = format!("az://{test_container_name}/test_azure_blob_from_env_glob_pattern/some/pg_parquet_test.parquet");
+
+        let azure_blob_uri_pattern = format!(
+            "az://{test_container_name}/test_azure_blob_from_env_glob_pattern/**/*.parquet"
+        );
+
+        let mut copy_options = HashMap::new();
+        copy_options.insert(
+            "file_size_bytes".to_string(),
+            CopyOptionValue::StringOption("1MB".to_string()),
+        );
+
+        let test_table = TestTable::<i32>::new("int4".into())
+            .with_uri(azure_blob_uri)
+            .with_uri_pattern(azure_blob_uri_pattern)
+            .with_order_by_col("a".into())
+            .with_copy_to_options(copy_options);
+
+        test_table.insert("INSERT INTO test_expected select i from generate_series(1, 1000000) i;");
+        test_table.assert_expected_and_result_rows();
     }
 
     #[pg_test]
@@ -644,6 +767,35 @@ mod tests {
     }
 
     #[pg_test]
+    #[should_panic(expected = "list operation on http(s) object stores is not supported")]
+    fn test_http_uri_glob_pattern() {
+        object_store_cache_clear();
+
+        let http_endpoint: String =
+            std::env::var("HTTP_ENDPOINT").expect("HTTP_ENDPOINT not found");
+
+        let http_uri =
+            format!("{http_endpoint}/test_http_uri_glob_pattern/some/pg_parquet_test.parquet");
+
+        let http_uri_pattern = format!("{http_endpoint}/test_http_uri_glob_pattern/**/*.parquet");
+
+        let mut copy_options = HashMap::new();
+        copy_options.insert(
+            "file_size_bytes".to_string(),
+            CopyOptionValue::StringOption("1MB".to_string()),
+        );
+
+        let test_table = TestTable::<i32>::new("int4".into())
+            .with_uri(http_uri)
+            .with_uri_pattern(http_uri_pattern)
+            .with_order_by_col("a".into())
+            .with_copy_to_options(copy_options);
+
+        test_table.insert("INSERT INTO test_expected select i from generate_series(1, 1000000) i;");
+        test_table.assert_expected_and_result_rows();
+    }
+
+    #[pg_test]
     fn test_gcs_from_env() {
         object_store_cache_clear();
 
@@ -655,6 +807,35 @@ mod tests {
         let test_table = TestTable::<i32>::new("int4".into()).with_uri(gcs_uri);
 
         test_table.insert("INSERT INTO test_expected (a) VALUES (1), (2), (null);");
+        test_table.assert_expected_and_result_rows();
+    }
+
+    #[pg_test]
+    fn test_gcs_from_env_glob_pattern() {
+        object_store_cache_clear();
+
+        let test_bucket_name: String =
+            std::env::var("GOOGLE_TEST_BUCKET").expect("GOOGLE_TEST_BUCKET not found");
+
+        let gcs_uri = format!(
+            "gs://{test_bucket_name}/test_gcs_from_env_glob_pattern/some/pg_parquet_test.parquet"
+        );
+
+        let gcs_uri_pattern = format!("gs://{test_bucket_name}/test_gcs_from_env_glob_pattern/**");
+
+        let mut copy_options = HashMap::new();
+        copy_options.insert(
+            "file_size_bytes".to_string(),
+            CopyOptionValue::StringOption("1MB".to_string()),
+        );
+
+        let test_table = TestTable::<i32>::new("int4".into())
+            .with_uri(gcs_uri)
+            .with_uri_pattern(gcs_uri_pattern)
+            .with_order_by_col("a".into())
+            .with_copy_to_options(copy_options);
+
+        test_table.insert("INSERT INTO test_expected select i from generate_series(1, 1000000) i;");
         test_table.assert_expected_and_result_rows();
     }
 

--- a/src/pgrx_tests/udfs.rs
+++ b/src/pgrx_tests/udfs.rs
@@ -1082,4 +1082,16 @@ mod tests {
             vec![]
         );
     }
+
+    #[pg_test]
+    #[should_panic(expected = "list operation on http(s) object stores is not supported")]
+    fn test_http_list_not_allowed() {
+        let http_endpoint: String =
+            std::env::var("HTTP_ENDPOINT").expect("HTTP_ENDPOINT not found");
+
+        let http_uri_pattern = format!("{http_endpoint}/**");
+
+        let parquet_list_command = format!("select * from parquet.list('{http_uri_pattern}');");
+        Spi::run(&parquet_list_command).unwrap();
+    }
 }

--- a/src/pgrx_tests/udfs.rs
+++ b/src/pgrx_tests/udfs.rs
@@ -2,7 +2,7 @@
 mod tests {
     use pgrx::{pg_test, Spi};
 
-    use crate::pgrx_tests::common::LOCAL_TEST_FILE_PATH;
+    use crate::pgrx_tests::common::{FileCleanup, LOCAL_TEST_FILE_PATH};
 
     #[pg_test]
     fn test_parquet_schema() {
@@ -1008,5 +1008,78 @@ mod tests {
         assert_eq!(result_column_stats, expected_column_stats);
 
         Spi::run("DROP TABLE column_stats_test; DROP TYPE person;").unwrap();
+    }
+
+    #[pg_test]
+    fn test_parquet_list() {
+        let _file_cleanup = FileCleanup::new(LOCAL_TEST_FILE_PATH);
+
+        let ddls = format!(
+            "
+            create table workers (id int, name text);
+            insert into workers select i, 'worker_' || i from generate_series(1, 1000000) i;
+            copy workers to '{LOCAL_TEST_FILE_PATH}' with (file_size_bytes '1MB');
+            "
+        );
+        Spi::run(&ddls).unwrap();
+
+        let fetch_result_uris = |uri_pattern| {
+            Spi::connect(|client| {
+                let parquet_list_command =
+                    format!("select * from parquet.list('{uri_pattern}') ORDER BY uri;");
+
+                let mut results = Vec::new();
+                let tup_table = client.select(&parquet_list_command, None, &[]).unwrap();
+
+                for row in tup_table {
+                    let uri = row["uri"].value::<String>().unwrap().unwrap();
+
+                    results.push((uri,));
+                }
+
+                results
+            })
+        };
+
+        assert_eq!(
+            fetch_result_uris(format!("{LOCAL_TEST_FILE_PATH}/**")),
+            vec![
+                (format!("{LOCAL_TEST_FILE_PATH}/data_0.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_1.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_2.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_3.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_4.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_5.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_6.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_7.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_8.parquet"),),
+            ]
+        );
+
+        assert_eq!(
+            fetch_result_uris(format!("{LOCAL_TEST_FILE_PATH}/*.parquet")),
+            vec![
+                (format!("{LOCAL_TEST_FILE_PATH}/data_0.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_1.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_2.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_3.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_4.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_5.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_6.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_7.parquet"),),
+                (format!("{LOCAL_TEST_FILE_PATH}/data_8.parquet"),),
+            ]
+        );
+
+        assert_eq!(
+            fetch_result_uris(format!("{LOCAL_TEST_FILE_PATH}/*_2.parquet")),
+            vec![(format!("{LOCAL_TEST_FILE_PATH}/data_2.parquet"),),]
+        );
+
+        // no match
+        assert_eq!(
+            fetch_result_uris(format!("{LOCAL_TEST_FILE_PATH}/*.csv")),
+            vec![]
+        );
     }
 }


### PR DESCRIPTION
- [x] Adds udf `parquet.list(<uri_with_pattern>)` where `uri_with_pattern` might contain `*` for words of arbitrary length or `**` for arbitrarily nested directories. 
- [x] Support `COPY FROM <uri_with_pattern>`.

```sql
COPY test1 TO '/tmp/parent/child/test1.parquet';
COPY test2 TO '/tmp/parent/child/test2.parquet';

COPY test3 FROM '/tmp/parent/**/*.parquet' WITH (format 'parquet');
```

**Warning**: list operation is not supported for http(s) object stores. (available for all other stores)

Closes #112.
