### PR TITLE
Copy to/from stdout/stdin with (format parquet)

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -28,4 +28,7 @@ GOOGLE_SERVICE_ACCOUNT_KEY='{"gcs_base_url": "http://localhost:4443","disable_oa
 GOOGLE_SERVICE_ENDPOINT=http://localhost:4443
 
 # Others
+# run pgrx tests with a single thread to avoid race conditions
 RUST_TEST_THREADS=1
+# pgrx runs test on the port base_port + pg_version
+PGRX_TEST_PG_BASE_PORT=5454

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
                                   postgresql-server-dev-${{ env.PG_MAJOR }} \
                                   postgresql-client-${{ env.PG_MAJOR }} \
                                   libpq-dev
+          echo "export PG_MAJOR=${{ env.PG_MAJOR }}" >> $GITHUB_ENV
 
       - name: Install azure-cli
         run: |
@@ -94,7 +95,8 @@ jobs:
       - name: Install and configure pgrx
         run: |
           cargo install --locked cargo-pgrx@0.13.1
-          cargo pgrx init --pg${{ env.PG_MAJOR }} /usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config
+          cargo pgrx init --pg${{ env.PG_MAJOR }} /usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config \
+                          --base-testing-port $PGRX_TEST_PG_BASE_PORT
 
       - name: Install cargo-llvm-cov for coverage report
         run: cargo install --locked cargo-llvm-cov@0.6.12

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI lints and tests](https://github.com/CrunchyData/pg_parquet/actions/workflows/ci.yml/badge.svg)](https://github.com/CrunchyData/pg_parquet/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/CrunchyData/pg_parquet/graph/badge.svg?token=6BPS0DSKJ2)](https://codecov.io/gh/CrunchyData/pg_parquet)
 
-`pg_parquet` is a PostgreSQL extension that allows you to read and write [Parquet files](https://parquet.apache.org), which are located in `S3` or `file system`, from PostgreSQL via `COPY TO/FROM` commands. It depends on [Apache Arrow](https://arrow.apache.org/rust/arrow/) project to read and write Parquet files and [pgrx](https://github.com/pgcentralfoundation/pgrx) project to extend PostgreSQL's `COPY` command.
+`pg_parquet` is a PostgreSQL extension that allows you to read and write [Parquet files](https://parquet.apache.org), which are located in `S3`, `Azure Blob Storage`, `Google Cloud Storage`, `http(s) endpoints` or `file system`, from PostgreSQL via `COPY TO/FROM` commands. It depends on [Apache Arrow](https://arrow.apache.org/rust/arrow/) project to read and write Parquet files and [pgrx](https://github.com/pgcentralfoundation/pgrx) project to extend PostgreSQL's `COPY` command.
 
 ```sql
 -- Copy a query result into Parquet in S3
@@ -61,7 +61,7 @@ There are mainly 3 things that you can do with `pg_parquet`:
 3. You can inspect the schema and metadata of Parquet files.
 
 ### COPY to/from Parquet files from/to Postgres tables
-You can use PostgreSQL's `COPY` command to read and write Parquet files. Below is an example of how to write a PostgreSQL table, with complex types, into a Parquet file and then to read the Parquet file content back into the same table.
+You can use PostgreSQL's `COPY` command to read and write from/to Parquet files. Below is an example of how to write a PostgreSQL table, with complex types, into a Parquet file and then to read the Parquet file content back into the same table.
 
 ```sql
 -- create composite types
@@ -97,6 +97,16 @@ COPY product_example FROM '/tmp/product_example.parquet';
 
 -- show table
 SELECT * FROM product_example;
+```
+
+You can also use `COPY` command to read and write Parquet stream from/to standard input and output. Below is an example usage (you have to specify `format = parquet`):
+
+```bash
+psql -d pg_parquet -p 28817 -h localhost -c "create table product_example_reconstructed (like product_example);"
+ CREATE TABLE
+
+psql -d pg_parquet -p 28817 -h localhost -c "copy product_example to stdout (format parquet);" | psql -d pg_parquet -p 28817 -h localhost -c "copy product_example_reconstructed from stdin (format parquet);"
+ COPY 2
 ```
 
 ### Inspect Parquet schema

--- a/src/arrow_parquet/parquet_reader.rs
+++ b/src/arrow_parquet/parquet_reader.rs
@@ -50,7 +50,11 @@ pub(crate) struct ParquetReaderContext {
 }
 
 impl ParquetReaderContext {
-    pub(crate) fn new(uri_info: ParsedUriInfo, match_by: MatchBy, tupledesc: &PgTupleDesc) -> Self {
+    pub(crate) fn new(
+        uri_info: &ParsedUriInfo,
+        match_by: MatchBy,
+        tupledesc: &PgTupleDesc,
+    ) -> Self {
         // Postgis and Map contexts are used throughout reading the parquet file.
         // We need to reset them to avoid reading the stale data. (e.g. extension could be dropped)
         reset_postgis_context();

--- a/src/arrow_parquet/parquet_writer.rs
+++ b/src/arrow_parquet/parquet_writer.rs
@@ -71,7 +71,7 @@ impl ParquetWriterContext {
 
         let writer_props = Self::writer_props(tupledesc, options);
 
-        let parquet_writer = parquet_writer_from_uri(uri_info, schema.clone(), writer_props);
+        let parquet_writer = parquet_writer_from_uri(&uri_info, schema.clone(), writer_props);
 
         let attribute_contexts =
             collect_pg_to_arrow_attribute_contexts(&attributes, &schema.fields);
@@ -130,7 +130,7 @@ impl ParquetWriterContext {
     }
 
     // finalize flushes the in progress rows to a new row group and finally writes metadata to the file.
-    fn finalize(&mut self) {
+    pub(crate) fn finalize(&mut self) {
         PG_BACKEND_TOKIO_RUNTIME
             .block_on(self.parquet_writer.finish())
             .unwrap_or_else(|e| panic!("failed to finish parquet writer: {}", e));
@@ -154,11 +154,5 @@ impl ParquetWriterContext {
         }
 
         RecordBatch::try_new(schema, attribute_arrays).expect("Expected record batch")
-    }
-}
-
-impl Drop for ParquetWriterContext {
-    fn drop(&mut self) {
-        self.finalize();
     }
 }

--- a/src/arrow_parquet/uri_utils.rs
+++ b/src/arrow_parquet/uri_utils.rs
@@ -43,7 +43,7 @@ pub(crate) struct ParsedUriInfo {
 }
 
 impl ParsedUriInfo {
-    pub(crate) fn for_stdout() -> Self {
+    pub(crate) fn for_std_inout() -> Self {
         // open temp postgres file, which is removed after transaction ends
         let tmp_path_fd = unsafe { OpenTemporaryFile(false) };
 

--- a/src/arrow_parquet/uri_utils.rs
+++ b/src/arrow_parquet/uri_utils.rs
@@ -1,4 +1,4 @@
-use std::{panic, sync::Arc};
+use std::{ffi::CStr, panic, sync::Arc};
 
 use arrow::datatypes::SchemaRef;
 use object_store::{path::Path, ObjectStoreScheme};
@@ -13,7 +13,11 @@ use parquet::{
 };
 use pgrx::{
     ereport,
-    pg_sys::{get_role_oid, has_privs_of_role, superuser, AsPgCStr, GetUserId},
+    ffi::c_char,
+    pg_sys::{
+        get_role_oid, has_privs_of_role, palloc0, superuser, AsPgCStr, DataDir, FileClose,
+        FilePathName, GetUserId, InvalidOid, OpenTemporaryFile, TempTablespacePath, MAXPGPATH,
+    },
 };
 use url::Url;
 
@@ -29,15 +33,48 @@ const PARQUET_OBJECT_STORE_READ_ROLE: &str = "parquet_object_store_read";
 const PARQUET_OBJECT_STORE_WRITE_ROLE: &str = "parquet_object_store_write";
 
 // ParsedUriInfo is a struct that holds the parsed uri information.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ParsedUriInfo {
     pub(crate) uri: Url,
     pub(crate) bucket: Option<String>,
     pub(crate) path: Path,
     pub(crate) scheme: ObjectStoreScheme,
+    pub(crate) stdio_tmp_fd: Option<i32>,
 }
 
 impl ParsedUriInfo {
+    pub(crate) fn for_stdout() -> Self {
+        // open temp postgres file, which is removed after transaction ends
+        let tmp_path_fd = unsafe { OpenTemporaryFile(false) };
+
+        let tmp_path = unsafe {
+            let data_dir = CStr::from_ptr(DataDir).to_str().expect("invalid base dir");
+
+            let tmp_tblspace_path: *const c_char = palloc0(MAXPGPATH as _) as _;
+            TempTablespacePath(tmp_tblspace_path as _, InvalidOid);
+            let tmp_tblspace_path = CStr::from_ptr(tmp_tblspace_path)
+                .to_str()
+                .expect("invalid temp tablespace path");
+
+            let tmp_file_path = FilePathName(tmp_path_fd);
+            let tmp_file_path = CStr::from_ptr(tmp_file_path)
+                .to_str()
+                .expect("invalid temp path");
+
+            let tmp_path = std::path::Path::new(data_dir)
+                .join(tmp_tblspace_path)
+                .join(tmp_file_path);
+
+            tmp_path.to_str().expect("invalid tmp path").to_string()
+        };
+
+        let mut parsed_uri = Self::try_from(tmp_path.as_str()).unwrap_or_else(|e| panic!("{}", e));
+
+        parsed_uri.stdio_tmp_fd = Some(tmp_path_fd);
+
+        parsed_uri
+    }
+
     fn try_parse_uri(uri: &str) -> Result<Url, String> {
         if !uri.contains("://") {
             // local file
@@ -92,7 +129,17 @@ impl TryFrom<&str> for ParsedUriInfo {
             bucket,
             path,
             scheme,
+            stdio_tmp_fd: None,
         })
+    }
+}
+
+impl Drop for ParsedUriInfo {
+    fn drop(&mut self) {
+        if let Some(stdio_tmp_fd) = self.stdio_tmp_fd {
+            // close temp file, postgres api will remove it on close
+            unsafe { FileClose(stdio_tmp_fd) };
+        }
     }
 }
 
@@ -109,7 +156,7 @@ pub(crate) fn uri_as_string(uri: &Url) -> String {
     uri.to_string()
 }
 
-pub(crate) fn parquet_schema_from_uri(uri_info: ParsedUriInfo) -> SchemaDescriptor {
+pub(crate) fn parquet_schema_from_uri(uri_info: &ParsedUriInfo) -> SchemaDescriptor {
     let parquet_reader = parquet_reader_from_uri(uri_info);
 
     let arrow_schema = parquet_reader.schema();
@@ -119,19 +166,18 @@ pub(crate) fn parquet_schema_from_uri(uri_info: ParsedUriInfo) -> SchemaDescript
         .unwrap_or_else(|e| panic!("{}", e))
 }
 
-pub(crate) fn parquet_metadata_from_uri(uri_info: ParsedUriInfo) -> Arc<ParquetMetaData> {
+pub(crate) fn parquet_metadata_from_uri(uri_info: &ParsedUriInfo) -> Arc<ParquetMetaData> {
+    let uri = uri_info.uri.clone();
+
     let copy_from = true;
-    let (parquet_object_store, location) = get_or_create_object_store(uri_info.clone(), copy_from);
+    let (parquet_object_store, location) = get_or_create_object_store(uri_info, copy_from);
 
     PG_BACKEND_TOKIO_RUNTIME.block_on(async {
         let object_store_meta = parquet_object_store
             .head(&location)
             .await
             .unwrap_or_else(|e| {
-                panic!(
-                    "failed to get object store metadata for uri {}: {}",
-                    uri_info.uri, e
-                )
+                panic!("failed to get object store metadata for uri {}: {}", uri, e)
             });
 
         let parquet_object_reader =
@@ -149,20 +195,19 @@ pub(crate) fn parquet_metadata_from_uri(uri_info: ParsedUriInfo) -> Arc<ParquetM
 pub(crate) const RECORD_BATCH_SIZE: i64 = 1024;
 
 pub(crate) fn parquet_reader_from_uri(
-    uri_info: ParsedUriInfo,
+    uri_info: &ParsedUriInfo,
 ) -> ParquetRecordBatchStream<ParquetObjectReader> {
+    let uri = uri_info.uri.clone();
+
     let copy_from = true;
-    let (parquet_object_store, location) = get_or_create_object_store(uri_info.clone(), copy_from);
+    let (parquet_object_store, location) = get_or_create_object_store(uri_info, copy_from);
 
     PG_BACKEND_TOKIO_RUNTIME.block_on(async {
         let object_store_meta = parquet_object_store
             .head(&location)
             .await
             .unwrap_or_else(|e| {
-                panic!(
-                    "failed to get object store metadata for uri {}: {}",
-                    uri_info.uri, e
-                )
+                panic!("failed to get object store metadata for uri {}: {}", uri, e)
             });
 
         let parquet_object_reader =
@@ -205,12 +250,12 @@ fn calculate_reader_batch_size(metadata: &Arc<ParquetMetaData>) -> usize {
 }
 
 pub(crate) fn parquet_writer_from_uri(
-    uri_info: ParsedUriInfo,
+    uri_info: &ParsedUriInfo,
     arrow_schema: SchemaRef,
     writer_props: WriterProperties,
 ) -> AsyncArrowWriter<ParquetObjectWriter> {
     let copy_from = false;
-    let (parquet_object_store, location) = get_or_create_object_store(uri_info.clone(), copy_from);
+    let (parquet_object_store, location) = get_or_create_object_store(uri_info, copy_from);
 
     let parquet_object_writer = ParquetObjectWriter::new(parquet_object_store, location);
 

--- a/src/object_store/object_store_cache.rs
+++ b/src/object_store/object_store_cache.rs
@@ -23,7 +23,7 @@ use super::{
 static mut OBJECT_STORE_CACHE: Lazy<ObjectStoreCache> = Lazy::new(ObjectStoreCache::new);
 
 pub(crate) fn get_or_create_object_store(
-    uri_info: ParsedUriInfo,
+    uri_info: &ParsedUriInfo,
     copy_from: bool,
 ) -> (Arc<dyn ObjectStore>, Path) {
     #[allow(static_mut_refs)]
@@ -45,15 +45,13 @@ impl ObjectStoreCache {
 
     fn get_or_create(
         &mut self,
-        uri_info: ParsedUriInfo,
+        uri_info: &ParsedUriInfo,
         copy_from: bool,
     ) -> (Arc<dyn ObjectStore>, Path) {
-        let ParsedUriInfo {
-            uri,
-            path,
-            scheme,
-            bucket,
-        } = uri_info;
+        let uri = uri_info.uri.clone();
+        let scheme = uri_info.scheme.clone();
+        let bucket = uri_info.bucket.clone();
+        let path = uri_info.path.clone();
 
         // no need to cache local files
         if scheme == ObjectStoreScheme::Local {

--- a/src/parquet_copy_hook.rs
+++ b/src/parquet_copy_hook.rs
@@ -1,7 +1,9 @@
 pub(crate) mod copy_from;
+pub(crate) mod copy_from_stdin;
 pub(crate) mod copy_to;
 pub(crate) mod copy_to_dest_receiver;
 pub(crate) mod copy_to_split_dest_receiver;
+pub(crate) mod copy_to_stdout;
 pub(crate) mod copy_utils;
 pub(crate) mod hook;
 pub(crate) mod pg_compat;

--- a/src/parquet_copy_hook/copy_from_stdin.rs
+++ b/src/parquet_copy_hook/copy_from_stdin.rs
@@ -1,0 +1,216 @@
+use std::{ffi::CStr, io::Write};
+
+use pgrx::{
+    ffi::c_char,
+    pg_sys::{
+        makeStringInfo, pq_beginmessage, pq_copymsgbytes, pq_endmessage, pq_getmsgstring,
+        pq_sendbyte, pq_sendint16, QueryCancelHoldoffCount, StringInfo,
+    },
+};
+
+use crate::arrow_parquet::uri_utils::{uri_as_string, ParsedUriInfo};
+
+/*
+ * CopyFromStdinState is a simplified version of CopyFromState
+ * in PostgreSQL to use in ReceiveDataFromClient with names
+ * preserved.
+ */
+struct CopyFromStdinState {
+    /* buffer in which we store incoming bytes */
+    fe_msgbuf: StringInfo,
+
+    /* whether we reached the end-of-file */
+    raw_reached_eof: bool,
+}
+
+const MAX_READ_SIZE: usize = 65536;
+
+/*
+ * CopyInputToFile copies data from the socket to the given file.
+ * We request the client send a specific column count.
+ */
+pub(crate) unsafe fn copy_stdin_to_file(uri_info: &ParsedUriInfo, natts: i16, is_binary: bool) {
+    let mut cstate = CopyFromStdinState {
+        fe_msgbuf: makeStringInfo(),
+        raw_reached_eof: false,
+    };
+
+    /* open the destination file for writing */
+    let path = uri_as_string(&uri_info.uri);
+
+    // create or overwrite the local file
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(&path)
+        .unwrap_or_else(|e| panic!("{}", e));
+
+    /* tell the client we are ready for data */
+    send_copy_in_begin(natts, is_binary);
+
+    /* allocate on the heap since it's quite big */
+    let mut receive_buffer = vec![0u8; MAX_READ_SIZE];
+
+    while !cstate.raw_reached_eof {
+        /* copy some bytes from the client into fe_msgbuf */
+        let bytes_read = receive_data_from_client(&mut cstate, &mut receive_buffer);
+
+        if bytes_read == 0 {
+            break;
+        }
+
+        if bytes_read > 0 {
+            /* copy bytes from fe_msgbuf to the destination file */
+            file.write_all(&receive_buffer[..bytes_read])
+                .unwrap_or_else(|e| {
+                    panic!("could not write to file: {}", e);
+                });
+        }
+    }
+}
+
+/*
+ * send_copy_in_begin sends the CopyInResponse message that the client
+ * expects after a COPY .. FROM STDIN.
+ *
+ * This code is adapted from ReceiveCopyBegin in PostgreSQL.
+ */
+unsafe fn send_copy_in_begin(natts: i16, is_binary: bool) {
+    let buf = makeStringInfo();
+
+    pq_beginmessage(buf, 'G' as _);
+
+    let copy_format = if is_binary { 1 } else { 0 };
+    pq_sendbyte(buf, copy_format);
+
+    pq_sendint16(buf, natts as _);
+    for _ in 0..natts {
+        /* use the same format for all columns */
+        pq_sendint16(buf, copy_format as _);
+    }
+
+    pq_endmessage(buf);
+    ((*PqCommMethods).flush)();
+}
+
+const PQ_LARGE_MESSAGE_LIMIT: i32 = 1024 * 1024 * 1024 - 3;
+const PQ_SMALL_MESSAGE_LIMIT: i32 = 10000;
+
+unsafe fn receive_data_from_client(
+    cstate: &mut CopyFromStdinState,
+    receive_buffer: &mut [u8],
+) -> usize {
+    let mut databuf = receive_buffer;
+
+    let minread = 1;
+    let mut maxread = MAX_READ_SIZE;
+
+    let mut bytesread = 0;
+
+    while maxread > 0 && bytesread < minread && !cstate.raw_reached_eof {
+        let mut avail;
+        let mut flushed = false;
+
+        while flushed || (*cstate.fe_msgbuf).cursor >= (*cstate.fe_msgbuf).len {
+            /* Try to receive another message */
+
+            QueryCancelHoldoffCount += 1;
+
+            pq_startmsgread();
+
+            let mtype = pq_getbyte();
+            if mtype == -1 {
+                panic!("unexpected EOF on client connection with an open transaction");
+            }
+
+            /* Validate message type and set packet size limit */
+            let maxmsglen = match mtype as u8 as char {
+                'd' =>
+                /* CopyData */
+                {
+                    PQ_LARGE_MESSAGE_LIMIT
+                }
+                'c' | 'f' | 'H' | 'S' =>
+                /* CopyDone, CopyFail, Flush, Sync */
+                {
+                    PQ_SMALL_MESSAGE_LIMIT
+                }
+                _ => {
+                    panic!(
+                        "unexpected message type 0x{:02X} during COPY from stdin",
+                        mtype
+                    );
+                }
+            };
+
+            /* Now collect the message body */
+            if pq_getmessage(cstate.fe_msgbuf, maxmsglen) != 0 {
+                panic!("unexpected EOF on client connection with an open transaction");
+            }
+
+            QueryCancelHoldoffCount -= 1;
+
+            /* ... and process it */
+            match mtype as u8 as char {
+                'd' => {
+                    /* CopyData */
+                    break;
+                }
+                'c' => {
+                    /* CopyDone */
+                    cstate.raw_reached_eof = true;
+                    return bytesread;
+                }
+                'f' => {
+                    /* CopyFail */
+                    let msg = pq_getmsgstring(cstate.fe_msgbuf);
+                    let msg = CStr::from_ptr(msg).to_str().expect("invalid CStr");
+                    panic!("COPY from stdin failed: {msg}");
+                }
+                'H' | 'S' => {
+                    /* Flush, Sync */
+                    flushed = true;
+                    continue;
+                }
+                _ => {
+                    panic!(
+                        "unexpected message type 0x{:02X} during COPY from stdin",
+                        mtype
+                    );
+                }
+            }
+        }
+
+        avail = ((*cstate.fe_msgbuf).len - (*cstate.fe_msgbuf).cursor) as _;
+        if avail > maxread {
+            avail = maxread;
+        }
+
+        pq_copymsgbytes(cstate.fe_msgbuf, databuf.as_mut_ptr() as _, avail as _);
+        databuf = &mut databuf[avail..];
+        maxread -= avail;
+        bytesread += avail;
+    }
+
+    bytesread
+}
+
+// todo: move to pgrx (include libpq.h)
+#[repr(C)]
+struct PQcommMethods {
+    comm_reset: unsafe extern "C" fn(),
+    flush: unsafe extern "C" fn() -> i32,
+    flush_if_writable: unsafe extern "C" fn() -> i32,
+    is_send_pending: unsafe extern "C" fn() -> bool,
+    putmessage: unsafe extern "C" fn(msgtype: u32, s: *const c_char, len: usize) -> i32,
+    putmessage_noblock: unsafe extern "C" fn(msgtype: u32, s: *const c_char, len: usize),
+}
+
+unsafe extern "C" {
+    fn pq_startmsgread();
+    fn pq_getmessage(s: StringInfo, maxlen: i32) -> i32;
+    fn pq_getbyte() -> i32;
+
+    static PqCommMethods: *mut PQcommMethods;
+}

--- a/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
+++ b/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
@@ -22,6 +22,7 @@ pub(crate) const INVALID_FILE_SIZE_BYTES: i64 = 0;
 struct CopyToParquetSplitDestReceiver {
     dest: DestReceiver,
     uri: *const c_char,
+    is_stdio: bool,
     tupledesc: TupleDesc,
     operation: i32,
     options: CopyToParquetOptions,
@@ -44,7 +45,8 @@ impl CopyToParquetSplitDestReceiver {
     fn create_new_child(&mut self) {
         // create a new child receiver
         let child_uri = self.create_uri_for_child();
-        self.current_child_receiver = create_copy_to_parquet_dest_receiver(child_uri, self.options);
+        self.current_child_receiver =
+            create_copy_to_parquet_dest_receiver(child_uri, self.is_stdio, self.options);
         self.current_child_id += 1;
 
         // start the child receiver
@@ -125,6 +127,18 @@ impl CopyToParquetSplitDestReceiver {
 
         child_uri.to_str().expect("invalid uri").as_pg_cstr()
     }
+
+    fn cleanup(&mut self) {
+        if self.current_child_receiver.is_null() {
+            return;
+        }
+
+        let mut child_parquet_dest = unsafe {
+            PgBox::<CopyToParquetDestReceiver>::from_pg(self.current_child_receiver as _)
+        };
+
+        child_parquet_dest.cleanup();
+    }
 }
 
 #[pg_guard]
@@ -181,8 +195,10 @@ extern "C" fn copy_split_destroy(_dest: *mut DestReceiver) {}
 // and have default values if not provided.
 #[pg_guard]
 #[no_mangle]
+#[allow(clippy::too_many_arguments)]
 pub extern "C" fn create_copy_to_parquet_split_dest_receiver(
     uri: *const c_char,
+    is_stdio: bool,
     file_size_bytes: *const i64,
     field_ids: *const c_char,
     row_group_size: *const i64,
@@ -246,10 +262,25 @@ pub extern "C" fn create_copy_to_parquet_split_dest_receiver(
     split_dest.dest.rDestroy = Some(copy_split_destroy);
     split_dest.dest.mydest = CommandDest::DestCopyOut;
     split_dest.uri = uri;
+    split_dest.is_stdio = is_stdio;
     split_dest.tupledesc = std::ptr::null_mut();
     split_dest.operation = -1;
     split_dest.options = options;
     split_dest.current_child_id = 0;
 
     unsafe { std::mem::transmute(split_dest) }
+}
+
+pub(crate) fn free_copy_to_parquet_split_dest_receiver(dest: *mut DestReceiver) {
+    if dest.is_null() {
+        return;
+    }
+
+    let split_dest = unsafe {
+        (dest as *mut CopyToParquetSplitDestReceiver)
+            .as_mut()
+            .expect("invalid parquet dest receiver ptr")
+    };
+
+    split_dest.cleanup();
 }

--- a/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
+++ b/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
@@ -22,7 +22,7 @@ pub(crate) const INVALID_FILE_SIZE_BYTES: i64 = 0;
 struct CopyToParquetSplitDestReceiver {
     dest: DestReceiver,
     uri: *const c_char,
-    is_stdio: bool,
+    is_to_stdout: bool,
     tupledesc: TupleDesc,
     operation: i32,
     options: CopyToParquetOptions,
@@ -46,7 +46,7 @@ impl CopyToParquetSplitDestReceiver {
         // create a new child receiver
         let child_uri = self.create_uri_for_child();
         self.current_child_receiver =
-            create_copy_to_parquet_dest_receiver(child_uri, self.is_stdio, self.options);
+            create_copy_to_parquet_dest_receiver(child_uri, self.is_to_stdout, self.options);
         self.current_child_id += 1;
 
         // start the child receiver
@@ -198,7 +198,7 @@ extern "C" fn copy_split_destroy(_dest: *mut DestReceiver) {}
 #[allow(clippy::too_many_arguments)]
 pub extern "C" fn create_copy_to_parquet_split_dest_receiver(
     uri: *const c_char,
-    is_stdio: bool,
+    is_to_stdout: bool,
     file_size_bytes: *const i64,
     field_ids: *const c_char,
     row_group_size: *const i64,
@@ -262,7 +262,7 @@ pub extern "C" fn create_copy_to_parquet_split_dest_receiver(
     split_dest.dest.rDestroy = Some(copy_split_destroy);
     split_dest.dest.mydest = CommandDest::DestCopyOut;
     split_dest.uri = uri;
-    split_dest.is_stdio = is_stdio;
+    split_dest.is_to_stdout = is_to_stdout;
     split_dest.tupledesc = std::ptr::null_mut();
     split_dest.operation = -1;
     split_dest.options = options;

--- a/src/parquet_copy_hook/copy_to_stdout.rs
+++ b/src/parquet_copy_hook/copy_to_stdout.rs
@@ -1,0 +1,83 @@
+use std::{fs::File, io::Read};
+
+use pgrx::pg_sys::{
+    makeStringInfo, pq_beginmessage, pq_endmessage, pq_putemptymessage, pq_sendbyte, pq_sendbytes,
+    pq_sendint16,
+};
+
+use crate::arrow_parquet::uri_utils::{uri_as_string, ParsedUriInfo};
+
+/*
+ * copy_file_to_stdout copies the raw contents of a file to the
+ * client as part of a COPY .. TO STDOUT.
+ */
+pub(crate) unsafe fn copy_file_to_stdout(uri_info: ParsedUriInfo, natts: i16) {
+    let path = uri_as_string(&uri_info.uri);
+
+    let mut file = File::open(path).unwrap_or_else(|e| {
+        panic!("could not open temp file: {}", e);
+    });
+
+    let is_binary = true;
+    send_copy_begin(natts, is_binary);
+
+    /* allocate on the heap since it's quite big */
+    const MAX_READ_SIZE: usize = 65536;
+    let mut send_buffer = vec![0u8; MAX_READ_SIZE];
+
+    loop {
+        let bytes_read = file.read(&mut send_buffer).unwrap_or_else(|e| {
+            panic!("could not read from temp file: {}", e);
+        });
+
+        if bytes_read == 0 {
+            break;
+        }
+
+        send_copy_data(&send_buffer[..bytes_read]);
+    }
+
+    send_copy_end();
+}
+
+/*
+ * send_copy_begin sends the CopyOutResponse message to start a
+ * COPY .. TO STDOUT.
+ *
+ * This code is adapted from SendCopyBegin in PostgreSQL.
+ */
+unsafe fn send_copy_begin(natts: i16, is_binary: bool) {
+    let buf = makeStringInfo();
+
+    pq_beginmessage(buf, 'H' as _);
+
+    let copy_format = if is_binary { 1 } else { 0 };
+    pq_sendbyte(buf, copy_format); /* overall format */
+
+    pq_sendint16(buf, natts as _);
+    for _ in 0..natts {
+        /* use the same format for all columns */
+        pq_sendint16(buf, copy_format as _);
+    }
+
+    pq_endmessage(buf);
+}
+
+/*
+ * send_copy_end sends the CopyDone message to end a
+ * COPY .. TO STDOUT.
+ */
+unsafe fn send_copy_end() {
+    pq_putemptymessage('c' as _);
+}
+
+/*
+ * send_copy_data sends a CopyData message containing the given buffer.
+ */
+unsafe fn send_copy_data(data: &[u8]) {
+    let buf = makeStringInfo();
+
+    pq_beginmessage(buf, 'd' as _);
+    pq_sendbytes(buf, data.as_ptr() as _, data.len() as _);
+    pq_endmessage(buf);
+}

--- a/src/parquet_copy_hook/copy_utils.rs
+++ b/src/parquet_copy_hook/copy_utils.rs
@@ -216,7 +216,7 @@ pub(crate) fn copy_stmt_uri(p_stmt: &PgBox<PlannedStmt>) -> Result<ParsedUriInfo
     }
 
     if copy_stmt.filename.is_null() {
-        return Ok(ParsedUriInfo::for_stdout());
+        return Ok(ParsedUriInfo::for_std_inout());
     }
 
     let uri = unsafe {

--- a/src/parquet_copy_hook/copy_utils.rs
+++ b/src/parquet_copy_hook/copy_utils.rs
@@ -33,7 +33,7 @@ use super::{
     pg_compat::strVal,
 };
 
-pub(crate) fn validate_copy_to_options(p_stmt: &PgBox<PlannedStmt>, uri_info: ParsedUriInfo) {
+pub(crate) fn validate_copy_to_options(p_stmt: &PgBox<PlannedStmt>, uri_info: &ParsedUriInfo) {
     validate_copy_option_names(
         p_stmt,
         &[
@@ -216,7 +216,7 @@ pub(crate) fn copy_stmt_uri(p_stmt: &PgBox<PlannedStmt>) -> Result<ParsedUriInfo
     }
 
     if copy_stmt.filename.is_null() {
-        return Err("filename is not specified".to_string());
+        return Ok(ParsedUriInfo::for_stdout());
     }
 
     let uri = unsafe {
@@ -279,12 +279,12 @@ pub(crate) fn copy_to_stmt_row_group_size_bytes(p_stmt: &PgBox<PlannedStmt>) -> 
 
 pub(crate) fn copy_to_stmt_compression(
     p_stmt: &PgBox<PlannedStmt>,
-    uri_info: ParsedUriInfo,
+    uri_info: &ParsedUriInfo,
 ) -> PgParquetCompression {
     let compression_option = copy_stmt_get_option(p_stmt, "compression");
 
     if compression_option.is_null() {
-        PgParquetCompression::try_from(uri_info.uri).unwrap_or_default()
+        PgParquetCompression::try_from(uri_info.uri.clone()).unwrap_or_default()
     } else {
         let compression = unsafe { defGetString(compression_option.as_ptr()) };
 
@@ -300,7 +300,7 @@ pub(crate) fn copy_to_stmt_compression(
 
 pub(crate) fn copy_to_stmt_compression_level(
     p_stmt: &PgBox<PlannedStmt>,
-    uri_info: ParsedUriInfo,
+    uri_info: &ParsedUriInfo,
 ) -> Option<i32> {
     let compression_level_option = copy_stmt_get_option(p_stmt, "compression_level");
 
@@ -397,10 +397,6 @@ fn is_copy_parquet_stmt(p_stmt: &PgBox<PlannedStmt>, copy_from: bool) -> bool {
     }
 
     if copy_stmt.is_program {
-        return false;
-    }
-
-    if copy_stmt.filename.is_null() {
         return false;
     }
 

--- a/src/parquet_udfs/metadata.rs
+++ b/src/parquet_udfs/metadata.rs
@@ -45,10 +45,8 @@ mod parquet {
             panic!("{}", e.to_string());
         });
 
-        let uri = uri_info.uri.clone();
-
-        ensure_access_privilege_to_uri(&uri, true);
-        let parquet_metadata = parquet_metadata_from_uri(uri_info);
+        ensure_access_privilege_to_uri(&uri_info.uri, true);
+        let parquet_metadata = parquet_metadata_from_uri(&uri_info);
 
         let mut rows = vec![];
 
@@ -103,7 +101,7 @@ mod parquet {
                 let total_uncompressed_size = column.uncompressed_size();
 
                 let row = (
-                    uri_as_string(&uri),
+                    uri_as_string(&uri_info.uri),
                     row_group_id as i64,
                     row_group_num_rows,
                     row_group_num_columns,
@@ -150,10 +148,8 @@ mod parquet {
             panic!("{}", e.to_string());
         });
 
-        let uri = uri_info.uri.clone();
-
-        ensure_access_privilege_to_uri(&uri, true);
-        let parquet_metadata = parquet_metadata_from_uri(uri_info);
+        ensure_access_privilege_to_uri(&uri_info.uri, true);
+        let parquet_metadata = parquet_metadata_from_uri(&uri_info);
 
         let created_by = parquet_metadata
             .file_metadata()
@@ -167,7 +163,7 @@ mod parquet {
         let format_version = parquet_metadata.file_metadata().version().to_string();
 
         let row = (
-            uri_as_string(&uri),
+            uri_as_string(&uri_info.uri),
             created_by,
             num_rows,
             num_row_groups,
@@ -192,10 +188,8 @@ mod parquet {
             panic!("{}", e.to_string());
         });
 
-        let uri = uri_info.uri.clone();
-
-        ensure_access_privilege_to_uri(&uri, true);
-        let parquet_metadata = parquet_metadata_from_uri(uri_info);
+        ensure_access_privilege_to_uri(&uri_info.uri, true);
+        let parquet_metadata = parquet_metadata_from_uri(&uri_info);
 
         let kv_metadata = parquet_metadata.file_metadata().key_value_metadata();
 
@@ -211,7 +205,7 @@ mod parquet {
             let key = kv.key.as_bytes().to_owned();
             let value = kv.value.as_ref().map(|v| v.as_bytes().to_owned());
 
-            let row = (uri_as_string(&uri), key, value);
+            let row = (uri_as_string(&uri_info.uri), key, value);
 
             rows.push(row);
         }

--- a/src/parquet_udfs/schema.rs
+++ b/src/parquet_udfs/schema.rs
@@ -36,10 +36,8 @@ mod parquet {
             panic!("{}", e.to_string());
         });
 
-        let uri = uri_info.uri.clone();
-
-        ensure_access_privilege_to_uri(&uri, true);
-        let parquet_schema = parquet_schema_from_uri(uri_info);
+        ensure_access_privilege_to_uri(&uri_info.uri, true);
+        let parquet_schema = parquet_schema_from_uri(&uri_info);
 
         let root_type = parquet_schema.root_schema();
         let thrift_schema_elements = to_thrift(root_type).unwrap_or_else(|e| {
@@ -72,7 +70,7 @@ mod parquet {
             let logical_type = schema_elem.logical_type.map(thrift_logical_type_to_str);
 
             let row = (
-                uri_as_string(&uri),
+                uri_as_string(&uri_info.uri),
                 name,
                 type_name,
                 type_length,

--- a/src/parquet_udfs/stats.rs
+++ b/src/parquet_udfs/stats.rs
@@ -112,10 +112,8 @@ mod parquet {
             panic!("{}", e.to_string());
         });
 
-        let uri = uri_info.uri.clone();
-
-        ensure_access_privilege_to_uri(&uri, true);
-        let parquet_metadata = parquet_metadata_from_uri(uri_info);
+        ensure_access_privilege_to_uri(&uri_info.uri, true);
+        let parquet_metadata = parquet_metadata_from_uri(&uri_info);
 
         let mut aggregated_column_stats = HashMap::new();
 

--- a/src/pgrx_tests/copy_stdin_out.rs
+++ b/src/pgrx_tests/copy_stdin_out.rs
@@ -1,0 +1,212 @@
+#[pgrx::pg_schema]
+mod tests {
+    use std::io::Read;
+    use std::io::Write;
+    use std::process::Command;
+    use std::process::Stdio;
+    use std::vec;
+
+    use pgrx::pg_test;
+    use pgrx::Spi;
+
+    use crate::pgrx_tests::common::LOCAL_TEST_FILE_PATH;
+
+    #[pg_test]
+    fn test_copy_stdin_out() {
+        let pg_version = std::env::var("PG_MAJOR").unwrap().parse::<i32>().unwrap();
+
+        let test_base_port = std::env::var("PGRX_TEST_PG_BASE_PORT")
+            .unwrap()
+            .parse::<i32>()
+            .unwrap();
+
+        let test_port = (test_base_port + pg_version).to_string();
+
+        // create test_expected
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg("CREATE TABLE test_expected (a int, b int generated always as (a + 2) stored);")
+            .output()
+            .expect("failed to execute process");
+        assert!(
+            output.status.success(),
+            "Failed to create test_expected table"
+        );
+
+        // create test_result
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg("CREATE TABLE test_result (a int, b int);")
+            .output()
+            .expect("failed to execute process");
+        assert!(
+            output.status.success(),
+            "Failed to create test_result table"
+        );
+
+        // insert data into test_expected
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(
+                "INSERT INTO test_expected SELECT i FROM generate_series(1, 3) i;
+                  INSERT INTO test_expected VALUES (NULL);",
+            )
+            .output()
+            .expect("failed to execute process");
+        assert!(
+            output.status.success(),
+            "Failed to insert into test_expected table"
+        );
+
+        // copy to stdout
+        let mut copy_to = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg("COPY test_expected TO STDOUT WITH (format parquet);")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("failed to execute process");
+
+        let mut buffer = Vec::new();
+        {
+            let copy_to_stdout = copy_to.stdout.as_mut().expect("Failed to open stdout");
+            copy_to_stdout
+                .read_to_end(&mut buffer)
+                .expect("Failed to read from stdout");
+
+            let status = copy_to.wait().expect("Failed to wait for 'copy_to'");
+            assert!(status.success(), "psql COPY TO process did not succeed");
+        }
+
+        // copy from stdin
+        let mut copy_from = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg("COPY test_result FROM STDIN WITH (format parquet);")
+            .stdin(Stdio::piped())
+            .spawn()
+            .expect("failed to execute process");
+
+        {
+            // Write the data we just read to the new child's stdin
+            let copy_from_stdin = copy_from.stdin.as_mut().expect("Failed to open stdin");
+            copy_from_stdin
+                .write_all(&buffer)
+                .expect("Failed to write to stdin");
+            copy_from_stdin.flush().expect("Failed to flush stdin");
+
+            let status = copy_from.wait().expect("Failed to wait for 'copy_from'");
+            assert!(status.success(), "psql COPY FROM process did not succeed");
+        }
+
+        // write to a file (this is needed because Spi::run cannot see external transactions)
+        let mut copy_to_file = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(format!(
+                "COPY test_result TO '{LOCAL_TEST_FILE_PATH}' with (format parquet);"
+            ))
+            .spawn()
+            .expect("failed to execute process");
+
+        let status = copy_to_file
+            .wait()
+            .expect("Failed to wait for 'copy_to_file'");
+        assert!(
+            status.success(),
+            "psql COPY TO FILE process did not succeed"
+        );
+
+        // assert table data
+        Spi::run("create temp table test_tmp (a int, b int);").unwrap();
+        Spi::run(format!("copy test_tmp from '{LOCAL_TEST_FILE_PATH}';").as_str()).unwrap();
+
+        let select_command = "SELECT * FROM test_tmp ORDER BY 1,2;";
+        let result = Spi::connect(|client| {
+            let mut results = Vec::new();
+            let tup_table = client.select(select_command, None, &[]).unwrap();
+
+            for row in tup_table {
+                let a = row["a"].value().unwrap();
+                let b = row["b"].value().unwrap();
+                results.push((a, b));
+            }
+
+            results
+        });
+
+        assert_eq!(
+            result,
+            [
+                (Some(1), Some(3)),
+                (Some(2), Some(4)),
+                (Some(3), Some(5)),
+                (None, None),
+            ]
+        );
+
+        // drop test_expected
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg("DROP TABLE test_expected;")
+            .output()
+            .expect("failed to execute process");
+        assert!(
+            output.status.success(),
+            "Failed to drop test_expected table"
+        );
+
+        // drop test_result
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg("DROP TABLE test_result;")
+            .output()
+            .expect("failed to execute process");
+        assert!(output.status.success(), "Failed to drop test_result table");
+    }
+}

--- a/src/pgrx_tests/mod.rs
+++ b/src/pgrx_tests/mod.rs
@@ -2,6 +2,7 @@ mod common;
 mod copy_from_coerce;
 mod copy_options;
 mod copy_pg_rules;
+mod copy_stdin_out;
 mod copy_type_roundtrip;
 mod gucs;
 mod object_store;

--- a/src/pgrx_utils.rs
+++ b/src/pgrx_utils.rs
@@ -61,8 +61,11 @@ pub(crate) fn is_generated_attribute(attribute: &FormData_pg_attribute) -> bool 
 }
 
 pub(crate) fn tuple_desc(typoid: Oid, typmod: i32) -> PgTupleDesc<'static> {
-    let tupledesc = unsafe { lookup_rowtype_tupdesc(typoid, typmod) };
-    unsafe { PgTupleDesc::from_pg(tupledesc) }
+    let tupledesc = unsafe { PgTupleDesc::from_pg(lookup_rowtype_tupdesc(typoid, typmod)) };
+
+    // return an owned copy of the tupledesc (needs pfree but not release) That prevents a bunch of
+    // errors during cleanup.
+    tupledesc.clone()
 }
 
 pub(crate) fn is_composite_type(typoid: Oid) -> bool {


### PR DESCRIPTION
We might use temp files as intermediate step. For COPY TO stdout, table => temp file => stdout. For COPY FROM stdin, stdin => file => table. There will be intermediate file IO overhead but this is the simplest and decent solution for now (considering most of the time will be lost during row to columnar conversions).

Closes #69.