### PR TITLE
Support parquet v2 format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
         runs_on: [ 'ubuntu-22.04', 'ubuntu-22.04-arm' ]
         include:
           - runs_on: ubuntu-22.04
-            arch: x64
+            arch: x86_64
           - runs_on: ubuntu-22.04-arm
-            arch: arm64
+            arch: aarch64
 
     runs-on: ${{ matrix.runs_on }}
 
@@ -36,44 +36,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up sccache for x86_64
-        if: ${{ matrix.arch == 'x64' }}
+      - name: Set up sccache
         run: |
-          wget https://github.com/mozilla/sccache/releases/download/v$SCCACHE_VERSION/sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz
-          tar -xzf sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz
-          sudo mv sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl/sccache /usr/local/bin
+          wget https://github.com/mozilla/sccache/releases/download/v$SCCACHE_VERSION/sccache-v$SCCACHE_VERSION-${{ matrix.arch }}-unknown-linux-musl.tar.gz
+          tar -xzf sccache-v$SCCACHE_VERSION-${{ matrix.arch }}-unknown-linux-musl.tar.gz
+          sudo mv sccache-v$SCCACHE_VERSION-${{ matrix.arch }}-unknown-linux-musl/sccache /usr/local/bin
           chmod +x /usr/local/bin/sccache
+          if [ "${{ matrix.arch }}" == "x86_64" ]; then
+            SCCACHE_SHA256=$SCCACHE_x86_64_SHA256
+          else
+            SCCACHE_SHA256=$SCCACHE_AARCH64_SHA256
+          fi
           echo "$SCCACHE_SHA256  /usr/local/bin/sccache" | sha256sum --check
         env:
           SCCACHE_VERSION: 0.8.1
-          SCCACHE_SHA256: "7203a4dcb3a67f3a0272366d50ede22e5faa3e2a798deaa4d1ea377b51c0ab0c"
+          SCCACHE_x86_64_SHA256: "7203a4dcb3a67f3a0272366d50ede22e5faa3e2a798deaa4d1ea377b51c0ab0c"
+          SCCACHE_AARCH64_SHA256: "36b2fd1c6c3a104ec1d526edb0533a3827c266054bf4552fb97f524beff6a612"
 
-      - name: Set up sccache for arm64
-        if: ${{ matrix.arch == 'arm64' }}
-        run: |
-          wget https://github.com/mozilla/sccache/releases/download/v$SCCACHE_VERSION/sccache-v$SCCACHE_VERSION-aarch64-unknown-linux-musl.tar.gz
-          tar -xzf sccache-v$SCCACHE_VERSION-aarch64-unknown-linux-musl.tar.gz
-          sudo mv sccache-v$SCCACHE_VERSION-aarch64-unknown-linux-musl/sccache /usr/local/bin
-          chmod +x /usr/local/bin/sccache
-          echo "$SCCACHE_SHA256  /usr/local/bin/sccache" | sha256sum --check
-        env:
-          SCCACHE_VERSION: 0.8.1
-          SCCACHE_SHA256: "36b2fd1c6c3a104ec1d526edb0533a3827c266054bf4552fb97f524beff6a612"
-
-      - name: Set up Rust for x86_64
-        if: ${{ matrix.arch == 'x64' }}
+      - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.88.0
-          target: x86_64-unknown-linux-gnu
-          components: rustfmt, clippy, llvm-tools-preview
-
-      - name: Set up Rust for arm64
-        if: ${{ matrix.arch == 'arm64' }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.88.0
-          target: aarch64-unknown-linux-gnu
+          toolchain: 1.89.0
+          target: ${{ matrix.arch }}-unknown-linux-gnu
           components: rustfmt, clippy, llvm-tools-preview
 
       - name: Cache cargo registry
@@ -150,17 +134,17 @@ jobs:
           make check-lint
 
       - name: Run tests without coverage
-        if: ${{ env.PG_MAJOR != '17' || matrix.arch != 'x64' }}
+        if: ${{ env.PG_MAJOR != '17' || matrix.arch != 'x86_64' }}
         run: |
           make check
 
       - name: Run tests with coverage
-        if: ${{ env.PG_MAJOR == '17' && matrix.arch == 'x64' }}
+        if: ${{ env.PG_MAJOR == '17' && matrix.arch == 'x86_64' }}
         run: |
           make check-with-coverage
 
       - name: Upload coverage report to Codecov
-        if: ${{ env.PG_MAJOR == '17' && matrix.arch == 'x64' }}
+        if: ${{ env.PG_MAJOR == '17' && matrix.arch == 'x86_64' }}
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -310,7 +310,8 @@ Supported Google Cloud Storage uri formats are shown below:
 - `row_group_size <int64>`: the number of rows in each row group while writing Parquet files. The default row group size is `122880`,
 - `row_group_size_bytes <int64>`: the total byte size of rows in each row group while writing Parquet files. The default row group size bytes is `row_group_size * 1024`,
 - `compression <string>`: the compression format to use while writing Parquet files. The supported compression formats are `uncompressed`, `snappy`, `gzip`, `brotli`, `lz4`, `lz4raw` and `zstd`. The default compression format is `snappy`. If not specified, the compression format is determined by the file extension,
-- `compression_level <int>`: the compression level to use while writing Parquet files. The supported compression levels are only supported for `gzip`, `zstd` and `brotli` compression formats. The default compression level is `6` for `gzip (0-10)`, `1` for `zstd (1-22)` and `1` for `brotli (0-11)`.
+- `compression_level <int>`: the compression level to use while writing Parquet files. The supported compression levels are only supported for `gzip`, `zstd` and `brotli` compression formats. The default compression level is `6` for `gzip (0-10)`, `1` for `zstd (1-22)` and `1` for `brotli (0-11)`,
+- `parquet_version <string>`: writer version of the Parquet file. By default, it is set to `v1` to be more interoperable with common query engines. (some are not able to read v2 files) You can set it to `v2` to unlock some of the new encodings.
 
 `pg_parquet` supports the following options in the `COPY FROM` command:
 - `format parquet`: you need to specify this option to read or write Parquet files which does not end with `.parquet[.<compression>]` extension,

--- a/src/arrow_parquet.rs
+++ b/src/arrow_parquet.rs
@@ -4,6 +4,7 @@ pub(crate) mod compression;
 pub(crate) mod field_ids;
 pub(crate) mod match_by;
 pub(crate) mod parquet_reader;
+pub(crate) mod parquet_version;
 pub(crate) mod parquet_writer;
 pub(crate) mod pg_to_arrow;
 pub(crate) mod schema_parser;

--- a/src/arrow_parquet/parquet_version.rs
+++ b/src/arrow_parquet/parquet_version.rs
@@ -1,0 +1,34 @@
+use std::str::FromStr;
+
+use parquet::file::properties::WriterVersion;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub(crate) enum ParquetVersion {
+    #[default]
+    V1,
+    V2,
+}
+
+impl FromStr for ParquetVersion {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "v1" => Ok(ParquetVersion::V1),
+            "v2" => Ok(ParquetVersion::V2),
+            _ => Err(format!(
+                "unrecognized parquet version: {s}. v1 or v2 is supported.",
+            )),
+        }
+    }
+}
+
+impl From<ParquetVersion> for WriterVersion {
+    fn from(value: ParquetVersion) -> Self {
+        match value {
+            ParquetVersion::V1 => WriterVersion::PARQUET_1_0,
+            ParquetVersion::V2 => WriterVersion::PARQUET_2_0,
+        }
+    }
+}

--- a/src/arrow_parquet/parquet_writer.rs
+++ b/src/arrow_parquet/parquet_writer.rs
@@ -94,6 +94,7 @@ impl ParquetWriterContext {
             .set_statistics_enabled(EnabledStatistics::Page)
             .set_compression(compression.into())
             .set_max_row_group_size(options.row_group_size as usize)
+            .set_writer_version(options.parquet_version.into())
             .set_created_by("pg_parquet".to_string());
 
         let geometry_columns_metadata_value = geoparquet_metadata_json_from_tupledesc(tupledesc);

--- a/src/parquet_copy_hook/hook.rs
+++ b/src/parquet_copy_hook/hook.rs
@@ -24,7 +24,7 @@ use super::{
     copy_to_split_dest_receiver::free_copy_to_parquet_split_dest_receiver,
     copy_utils::{
         copy_to_stmt_compression, copy_to_stmt_field_ids, copy_to_stmt_file_size_bytes,
-        validate_copy_from_options, validate_copy_to_options,
+        copy_to_stmt_parquet_version, validate_copy_from_options, validate_copy_to_options,
     },
 };
 
@@ -64,6 +64,7 @@ fn process_copy_to_parquet(
     let row_group_size_bytes = copy_to_stmt_row_group_size_bytes(p_stmt);
     let compression = copy_to_stmt_compression(p_stmt, &uri_info);
     let compression_level = copy_to_stmt_compression_level(p_stmt, &uri_info);
+    let parquet_version = copy_to_stmt_parquet_version(p_stmt);
 
     let parquet_split_dest = create_copy_to_parquet_split_dest_receiver(
         uri_as_string(&uri_info.uri).as_pg_cstr(),
@@ -74,6 +75,7 @@ fn process_copy_to_parquet(
         &row_group_size_bytes,
         &compression,
         &compression_level.unwrap_or(INVALID_COMPRESSION_LEVEL),
+        &parquet_version,
     );
 
     let parquet_split_dest = unsafe { PgBox::from_pg(parquet_split_dest) };

--- a/src/pgrx_tests/common.rs
+++ b/src/pgrx_tests/common.rs
@@ -229,21 +229,16 @@ where
 }
 
 pub(crate) fn assert_int_text_map(expected: Option<Map>, actual: Option<Map>) {
-    if expected.is_none() {
-        assert!(actual.is_none());
-    } else {
+    if let Some(expected) = expected {
         assert!(actual.is_some());
 
-        let expected = expected.unwrap().entries;
+        let expected = expected.entries;
         let actual = actual.unwrap().entries;
 
         for (expected, actual) in expected.iter().zip(actual.iter()) {
-            if expected.is_none() {
-                assert!(actual.is_none());
-            } else {
+            if let Some(expected) = expected {
                 assert!(actual.is_some());
 
-                let expected = expected.unwrap();
                 let actual = actual.unwrap();
 
                 let expected_key: Option<i32> = expected.get_by_name("key").unwrap();
@@ -255,21 +250,20 @@ pub(crate) fn assert_int_text_map(expected: Option<Map>, actual: Option<Map>) {
                 let actual_val: Option<String> = actual.get_by_name("val").unwrap();
 
                 assert_eq!(expected_val, actual_val);
+            } else {
+                assert!(actual.is_none());
             }
         }
+    } else {
+        assert!(actual.is_none());
     }
 }
 
 pub(crate) fn assert_float(expected_result: Vec<Option<f32>>, result: Vec<Option<f32>>) {
     for (expected, actual) in expected_result.into_iter().zip(result.into_iter()) {
-        if expected.is_none() {
-            assert!(actual.is_none());
-        }
-
-        if expected.is_some() {
+        if let Some(expected) = expected {
             assert!(actual.is_some());
 
-            let expected = expected.unwrap();
             let actual = actual.unwrap();
 
             if expected.is_nan() {
@@ -280,20 +274,17 @@ pub(crate) fn assert_float(expected_result: Vec<Option<f32>>, result: Vec<Option
             } else {
                 assert_eq!(expected, actual);
             }
+        } else {
+            assert!(actual.is_none());
         }
     }
 }
 
 pub(crate) fn assert_double(expected_result: Vec<Option<f64>>, result: Vec<Option<f64>>) {
     for (expected, actual) in expected_result.into_iter().zip(result.into_iter()) {
-        if expected.is_none() {
-            assert!(actual.is_none());
-        }
-
-        if expected.is_some() {
+        if let Some(expected) = expected {
             assert!(actual.is_some());
 
-            let expected = expected.unwrap();
             let actual = actual.unwrap();
 
             if expected.is_nan() {
@@ -304,40 +295,36 @@ pub(crate) fn assert_double(expected_result: Vec<Option<f64>>, result: Vec<Optio
             } else {
                 assert_eq!(expected, actual);
             }
+        } else {
+            assert!(actual.is_none());
         }
     }
 }
 
 pub(crate) fn assert_json(expected: Vec<Option<Json>>, result: Vec<Option<Json>>) {
     for (expected, actual) in expected.into_iter().zip(result.into_iter()) {
-        if expected.is_none() {
-            assert!(actual.is_none());
-        }
-
-        if expected.is_some() {
+        if let Some(expected) = expected {
             assert!(actual.is_some());
 
-            let expected = expected.unwrap();
             let actual = actual.unwrap();
 
             assert_eq!(expected.0, actual.0);
+        } else {
+            assert!(actual.is_none());
         }
     }
 }
 
 pub(crate) fn assert_jsonb(expected: Vec<Option<JsonB>>, result: Vec<Option<JsonB>>) {
     for (expected, actual) in expected.into_iter().zip(result.into_iter()) {
-        if expected.is_none() {
-            assert!(actual.is_none());
-        }
-
-        if expected.is_some() {
+        if let Some(expected) = expected {
             assert!(actual.is_some());
 
-            let expected = expected.unwrap();
             let actual = actual.unwrap();
 
             assert_eq!(expected.0, actual.0);
+        } else {
+            assert!(actual.is_none());
         }
     }
 }

--- a/src/pgrx_tests/copy_options.rs
+++ b/src/pgrx_tests/copy_options.rs
@@ -420,10 +420,8 @@ mod tests {
     fn test_parquet_version() {
         let fetch_parquet_version = || {
             Spi::connect(|client| {
-                let parquet_file_metadata_command = format!(
-                    "select * from parquet.file_metadata('{}');",
-                    LOCAL_TEST_FILE_PATH
-                );
+                let parquet_file_metadata_command =
+                    format!("select * from parquet.file_metadata('{LOCAL_TEST_FILE_PATH}');",);
 
                 let mut results = Vec::new();
                 let tup_table = client

--- a/src/pgrx_tests/copy_options.rs
+++ b/src/pgrx_tests/copy_options.rs
@@ -295,6 +295,22 @@ mod tests {
     }
 
     #[pg_test]
+    #[should_panic(expected = "unrecognized parquet version: vv2. v1 or v2 is supported.")]
+    fn test_invalid_parquet_version() {
+        let _file_cleanup = FileCleanup::new(LOCAL_TEST_FILE_PATH);
+
+        let mut copy_options = HashMap::new();
+        copy_options.insert(
+            "parquet_version".to_string(),
+            CopyOptionValue::StringOption("vv2".into()),
+        );
+
+        let test_table = TestTable::<i32>::new("int4".into()).with_copy_to_options(copy_options);
+        test_table.insert("INSERT INTO test_expected (a) VALUES (1), (2), (null);");
+        test_table.assert_expected_and_result_rows();
+    }
+
+    #[pg_test]
     fn test_large_arrow_array_limit() {
         // disable row group size bytes limit
         let mut copy_options = HashMap::new();
@@ -398,6 +414,62 @@ mod tests {
         });
 
         assert_eq!(result_metadata, vec![12]);
+    }
+
+    #[pg_test]
+    fn test_parquet_version() {
+        let fetch_parquet_version = || {
+            Spi::connect(|client| {
+                let parquet_file_metadata_command = format!(
+                    "select * from parquet.file_metadata('{}');",
+                    LOCAL_TEST_FILE_PATH
+                );
+
+                let mut results = Vec::new();
+                let tup_table = client
+                    .select(&parquet_file_metadata_command, None, &[])
+                    .unwrap();
+
+                for row in tup_table {
+                    let parquet_version = row["format_version"].value::<String>().unwrap().unwrap();
+                    results.push(parquet_version);
+                }
+
+                results
+            })
+        };
+
+        // try writing/reading from parquet v2 file
+        let mut copy_to_options = HashMap::new();
+        copy_to_options.insert(
+            "parquet_version".to_string(),
+            CopyOptionValue::StringOption("v2".to_string()),
+        );
+
+        let test_table = TestTable::<i32>::new("int4".into()).with_copy_to_options(copy_to_options);
+        test_table.insert("INSERT INTO test_expected (a) select i from generate_series(1,10) i;");
+        test_table.assert_expected_and_result_rows();
+
+        // v2
+        let copy_to_parquet = format!(
+            "copy (select 1 as id) to '{LOCAL_TEST_FILE_PATH}' with (parquet_version 'v2');",
+        );
+        Spi::run(&copy_to_parquet).unwrap();
+        assert_eq!(fetch_parquet_version(), vec!["2".to_string()]);
+
+        // v1
+        let copy_to_parquet = format!(
+            "copy (select 1 as id) to '{LOCAL_TEST_FILE_PATH}' with (parquet_version 'v1');",
+        );
+        Spi::run(&copy_to_parquet).unwrap();
+        assert_eq!(fetch_parquet_version(), vec!["1".to_string()]);
+
+        // V1
+        let copy_to_parquet = format!(
+            "copy (select 1 as id) to '{LOCAL_TEST_FILE_PATH}' with (parquet_version 'V1');",
+        );
+        Spi::run(&copy_to_parquet).unwrap();
+        assert_eq!(fetch_parquet_version(), vec!["1".to_string()]);
     }
 
     #[pg_test]

--- a/src/pgrx_tests/copy_type_roundtrip.rs
+++ b/src/pgrx_tests/copy_type_roundtrip.rs
@@ -91,17 +91,14 @@ mod tests {
         let TestResult { expected, result } = test_table.select_expected_and_result_rows();
 
         for ((expected,), (result,)) in expected.into_iter().zip(result.into_iter()) {
-            if expected.is_none() {
-                assert!(result.is_none());
-            }
-
-            if expected.is_some() {
+            if let Some(expected) = expected {
                 assert!(result.is_some());
 
-                let expected = expected.unwrap();
                 let result = result.unwrap();
 
                 assert_float(expected, result);
+            } else {
+                assert!(result.is_none());
             }
         }
     }
@@ -128,17 +125,14 @@ mod tests {
         let TestResult { expected, result } = test_table.select_expected_and_result_rows();
 
         for ((expected,), (result,)) in expected.into_iter().zip(result.into_iter()) {
-            if expected.is_none() {
-                assert!(result.is_none());
-            }
-
-            if expected.is_some() {
+            if let Some(expected) = expected {
                 assert!(result.is_some());
 
-                let expected = expected.unwrap();
                 let result = result.unwrap();
 
                 assert_double(expected, result);
+            } else {
+                assert!(result.is_none());
             }
         }
     }
@@ -345,19 +339,16 @@ mod tests {
         let TestResult { expected, result } = test_table.select_expected_and_result_rows();
 
         for ((expected,), (actual,)) in expected.into_iter().zip(result.into_iter()) {
-            if expected.is_none() {
-                assert!(actual.is_none());
-            }
-
-            if expected.is_some() {
+            if let Some(expected) = expected {
                 assert!(actual.is_some());
 
-                let expected = expected.unwrap();
                 let actual = actual.unwrap();
 
                 for (expected, actual) in expected.iter().zip(actual.iter()) {
                     assert_eq!(expected, actual);
                 }
+            } else {
+                assert!(actual.is_none());
             }
         }
     }
@@ -417,17 +408,16 @@ mod tests {
         let TestResult { expected, result } = test_table.select_expected_and_result_rows();
 
         for ((expected,), (actual,)) in expected.into_iter().zip(result.into_iter()) {
-            if expected.is_none() {
-                assert!(actual.is_none());
-            } else {
+            if let Some(expected) = expected {
                 assert!(actual.is_some());
 
-                let expected = expected.unwrap();
                 let actual = actual.unwrap();
 
                 for (expected, actual) in expected.into_iter().zip(actual.into_iter()) {
                     assert_int_text_map(expected, actual);
                 }
+            } else {
+                assert!(actual.is_none());
             }
         }
     }
@@ -732,17 +722,14 @@ mod tests {
         let TestResult { expected, result } = test_table.select_expected_and_result_rows();
 
         for ((expected,), (result,)) in expected.into_iter().zip(result.into_iter()) {
-            if expected.is_none() {
-                assert!(result.is_none());
-            }
-
-            if expected.is_some() {
+            if let Some(expected) = expected {
                 assert!(result.is_some());
 
-                let expected = expected.unwrap();
                 let result = result.unwrap();
 
                 assert_json(expected, result);
+            } else {
+                assert!(result.is_none());
             }
         }
     }
@@ -766,17 +753,14 @@ mod tests {
         let TestResult { expected, result } = test_table.select_expected_and_result_rows();
 
         for ((expected,), (result,)) in expected.into_iter().zip(result.into_iter()) {
-            if expected.is_none() {
-                assert!(result.is_none());
-            }
-
-            if expected.is_some() {
+            if let Some(expected) = expected {
                 assert!(result.is_some());
 
-                let expected = expected.unwrap();
                 let result = result.unwrap();
 
                 assert_jsonb(expected, result);
+            } else {
+                assert!(result.is_none());
             }
         }
     }
@@ -1245,12 +1229,9 @@ mod tests {
         });
 
         for (expected, actual) in expected_result.into_iter().zip(result.into_iter()) {
-            if expected.is_none() {
-                assert!(actual.is_none());
-            } else if expected.is_some() {
+            if let Some(expected) = expected {
                 assert!(actual.is_some());
 
-                let expected = expected.unwrap();
                 let actual = actual.unwrap();
 
                 assert_eq!(
@@ -1265,21 +1246,15 @@ mod tests {
                     .get_by_name::<pgrx::Array<composite_type!("dog")>>("dogs")
                     .unwrap();
 
-                if expected_dogs.is_none() {
-                    assert!(actual_dogs.is_none());
-                } else if expected_dogs.is_some() {
+                if let Some(expected_dogs) = expected_dogs {
                     assert!(actual_dogs.is_some());
 
-                    let expected_dogs = expected_dogs.unwrap();
                     let actual_dogs = actual_dogs.unwrap();
 
                     for (expected_dog, actual_dog) in expected_dogs.iter().zip(actual_dogs.iter()) {
                         if expected_dog.is_none() {
                             assert!(actual_dog.is_none());
-                        } else if expected_dog.is_some() {
-                            assert!(actual_dog.is_some());
-
-                            let expected_dog = expected_dog.unwrap();
+                        } else if let Some(expected_dog) = expected_dog {
                             let actual_dog = actual_dog.unwrap();
 
                             assert_eq!(
@@ -1293,6 +1268,8 @@ mod tests {
                             );
                         }
                     }
+                } else {
+                    assert!(actual_dogs.is_none());
                 }
 
                 let expected_lucky_numbers = expected
@@ -1303,12 +1280,7 @@ mod tests {
                     .get_by_name::<pgrx::Array<i32>>("lucky_numbers")
                     .unwrap();
 
-                if expected_lucky_numbers.is_none() {
-                    assert!(actual_lucky_numbers.is_none());
-                } else if expected_lucky_numbers.is_some() {
-                    assert!(actual_lucky_numbers.is_some());
-
-                    let expected_lucky_numbers = expected_lucky_numbers.unwrap();
+                if let Some(expected_lucky_numbers) = expected_lucky_numbers {
                     let actual_lucky_numbers = actual_lucky_numbers.unwrap();
 
                     for (expected_lucky_number, actual_lucky_number) in expected_lucky_numbers
@@ -1317,7 +1289,11 @@ mod tests {
                     {
                         assert_eq!(expected_lucky_number, actual_lucky_number);
                     }
+                } else {
+                    assert!(actual_lucky_numbers.is_none());
                 }
+            } else {
+                assert!(actual.is_none());
             }
         }
 


### PR DESCRIPTION
Supports reading or writing parquet files with format v2. By default, we write files in v1 format to improve interop with common query engines. But you can specify `COPY table TO '..' with (parquet_version 'v2')`.

Closes #104.