### PR TITLE
fix crash with pgaudit

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,6 +30,9 @@ RUN chmod a+rwx `pg_config --pkglibdir`          \
                 `pg_config --sharedir`/extension \
                 /var/run/postgresql/
 
+# install pgaudit
+RUN apt-get update && apt-get -y install postgresql-${PG_MAJOR}-pgaudit
+
 # initdb requires non-root user. This will also be the user that runs the container.
 ARG USERNAME=rust
 ARG USER_UID=1000
@@ -49,7 +52,7 @@ ENV PATH="/home/rust/.cargo/bin:${PATH}"
 ARG PGRX_VERSION=0.14.1
 RUN cargo install --locked cargo-pgrx@${PGRX_VERSION}
 RUN cargo pgrx init --pg${PG_MAJOR} $(which pg_config)
-RUN echo "shared_preload_libraries = 'pg_parquet'" >> $HOME/.pgrx/data-${PG_MAJOR}/postgresql.conf
+RUN echo "shared_preload_libraries = 'pgaudit,pg_parquet'" >> $HOME/.pgrx/data-${PG_MAJOR}/postgresql.conf
 
 # required for pgrx to work
 ENV USER=$USERNAME

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
                                   libpq-dev
           echo "export PG_MAJOR=${{ env.PG_MAJOR }}" >> $GITHUB_ENV
 
+      - name: Install pgaudit extension
+        run: |
+          sudo apt-get install -y postgresql-${{ env.PG_MAJOR }}-pgaudit
+
       - name: Install azure-cli
         run: |
           curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,9 @@ pub mod pg_test {
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
         // return any postgresql.conf settings that are required for your tests
-        vec!["shared_preload_libraries = 'pg_parquet'"]
+        vec![
+            "shared_preload_libraries = 'pgaudit,pg_parquet'",
+            "pgaudit.log = 'write'",
+        ]
     }
 }


### PR DESCRIPTION
There is an incompatibility between pgaudit and COPY commands. pgaudit expects its own prev_standardUtility to be called before the executor permission check hook is called. However, our COPY command does not call prev_standardUtility, so pgaudit crashes. Instead, here we disable pgaudit for the duration of the COPY command. See https://github.com/pgaudit/pgaudit/issues/212

An example flow to trigger crash before this PR:

```sql
CREATE TABLE test(a int);
COPY (SELECT 1) TO '/tmp/test.parquet';
SET audit.log TO 'write';
COPY test FROM '/tmp/test.parquet';
```

After this PR, the crash won't happen but at the cost of not auditing "copy from parquet" commands.