### PR TITLE
Improve makefile and ci

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -10,13 +10,13 @@ MINIO_ROOT_PASSWORD=minioadmin
 
 # Azure Blob tests
 AZURE_STORAGE_ACCOUNT=devstoreaccount1
-AZURE_STORAGE_KEY="Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+AZURE_STORAGE_KEY=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
 AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;"
 AZURE_STORAGE_ENDPOINT=http://localhost:10000/devstoreaccount1
 AZURE_ALLOW_HTTP=true
 AZURE_TEST_CONTAINER_NAME=testcontainer
-AZURE_TEST_READ_ONLY_SAS="se=2100-05-05&sp=r&sv=2022-11-02&sr=c&sig=YMPFnAHKe9y0o3hFegncbwQTXtAyvsJEgPB2Ne1b9CQ%3D"
-AZURE_TEST_READ_WRITE_SAS="se=2100-05-05&sp=rcw&sv=2022-11-02&sr=c&sig=TPz2jEz0t9L651t6rTCQr%2BOjmJHkM76tnCGdcyttnlA%3D"
+AZURE_TEST_READ_ONLY_SAS=se=2100-05-05&sp=r&sv=2022-11-02&sr=c&sig=YMPFnAHKe9y0o3hFegncbwQTXtAyvsJEgPB2Ne1b9CQ%3D
+AZURE_TEST_READ_WRITE_SAS=se=2100-05-05&sp=rcw&sv=2022-11-02&sr=c&sig=TPz2jEz0t9L651t6rTCQr%2BOjmJHkM76tnCGdcyttnlA%3D
 
 # http(s) tests
 ALLOW_HTTP=true
@@ -24,7 +24,7 @@ HTTP_ENDPOINT=http://localhost:8080
 
 # GCS tests
 GOOGLE_TEST_BUCKET=testbucket
-GOOGLE_SERVICE_ACCOUNT_KEY='{"gcs_base_url": "http://localhost:4443","disable_oauth": true,"client_email": "","private_key_id": "","private_key": ""}'
+GOOGLE_SERVICE_ACCOUNT_KEY={"gcs_base_url":"http://localhost:4443","disable_oauth":true,"client_email":"","private_key_id":"","private_key":""}
 GOOGLE_SERVICE_ENDPOINT=http://localhost:4443
 
 # Others

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI lints and tests
+name: Build and tests
 on:
   push:
     branches: [ "main" ]
@@ -17,17 +17,27 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         postgres: [ 14, 15, 16, 17 ]
+        runs_on: [ 'ubuntu-22.04', 'ubuntu-22.04-arm' ]
+        include:
+          - runs_on: ubuntu-22.04
+            arch: x64
+          - runs_on: ubuntu-22.04-arm
+            arch: arm64
+
+    runs-on: ${{ matrix.runs_on }}
+
     env:
       PG_MAJOR: ${{ matrix.postgres }}
+      PG_CONFIG: /usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up sccache
+      - name: Set up sccache for x86_64
+        if: ${{ matrix.arch == 'x64' }}
         run: |
           wget https://github.com/mozilla/sccache/releases/download/v$SCCACHE_VERSION/sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz
           tar -xzf sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz
@@ -38,11 +48,32 @@ jobs:
           SCCACHE_VERSION: 0.8.1
           SCCACHE_SHA256: "7203a4dcb3a67f3a0272366d50ede22e5faa3e2a798deaa4d1ea377b51c0ab0c"
 
-      - name: Set up Rust
+      - name: Set up sccache for arm64
+        if: ${{ matrix.arch == 'arm64' }}
+        run: |
+          wget https://github.com/mozilla/sccache/releases/download/v$SCCACHE_VERSION/sccache-v$SCCACHE_VERSION-aarch64-unknown-linux-musl.tar.gz
+          tar -xzf sccache-v$SCCACHE_VERSION-aarch64-unknown-linux-musl.tar.gz
+          sudo mv sccache-v$SCCACHE_VERSION-aarch64-unknown-linux-musl/sccache /usr/local/bin
+          chmod +x /usr/local/bin/sccache
+          echo "$SCCACHE_SHA256  /usr/local/bin/sccache" | sha256sum --check
+        env:
+          SCCACHE_VERSION: 0.8.1
+          SCCACHE_SHA256: "36b2fd1c6c3a104ec1d526edb0533a3827c266054bf4552fb97f524beff6a612"
+
+      - name: Set up Rust for x86_64
+        if: ${{ matrix.arch == 'x64' }}
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.86.0
           target: x86_64-unknown-linux-gnu
+          components: rustfmt, clippy, llvm-tools-preview
+
+      - name: Set up Rust for arm64
+        if: ${{ matrix.arch == 'arm64' }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.86.0
+          target: aarch64-unknown-linux-gnu
           components: rustfmt, clippy, llvm-tools-preview
 
       - name: Cache cargo registry
@@ -56,21 +87,14 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: pg_parquet-rust-cache-${{ runner.os }}-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
+          key: pg_parquet-rust-cache-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
 
       - name: Cache sccache directory
         uses: actions/cache@v4
         continue-on-error: false
         with:
           path: ${{ env.SCCACHE_DIR }}
-          key: pg_parquet-sccache-cache-${{ runner.os }}-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
-
-      - name: Export environment variables from .env file
-        uses: falti/dotenv-action@v1
-        with:
-          path: .devcontainer/.env
-          export-variables: true
-          keys-case: bypass
+          key: pg_parquet-sccache-cache-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
 
       - name: Install PostgreSQL
         run: |
@@ -96,19 +120,12 @@ jobs:
           echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ `lsb_release -cs` main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update && sudo apt-get install -y azure-cli
 
-      - name: Install and configure pgrx
+      - name: Install pgrx
         run: |
           cargo install --locked cargo-pgrx@0.14.1
-          cargo pgrx init --pg${{ env.PG_MAJOR }} /usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config \
-                          --base-testing-port $PGRX_TEST_PG_BASE_PORT
 
       - name: Install cargo-llvm-cov for coverage report
         run: cargo install --locked cargo-llvm-cov@0.6.12
-
-      - name: Format and lint
-        run: |
-          cargo fmt --all -- --check
-          cargo clippy --all-targets --features "pg${{ env.PG_MAJOR }}, pg_test" --no-default-features -- -D warnings
 
       - name: Set up permissions for PostgreSQL
         run: |
@@ -116,75 +133,23 @@ jobs:
                            $(/usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config --sharedir)/extension \
                            /var/run/postgresql/
 
-      - name: Start Minio for s3 emulator tests
+      - name: Check format and lint
         run: |
-          docker run -d \
-            --env-file .devcontainer/.env \
-            -p 9000:9000 \
-            --entrypoint "./entrypoint.sh" \
-            --volume ./.devcontainer/minio-entrypoint.sh:/entrypoint.sh \
-            minio/minio
+          make check-format
+          make check-lint
 
-          while ! curl $AWS_ENDPOINT_URL; do
-            echo "Waiting for $AWS_ENDPOINT_URL..."
-            sleep 1
-          done
-
-      - name: Start Azurite for Azure Blob Storage emulator tests
+      - name: Run tests without coverage
+        if: ${{ env.PG_MAJOR != '17' || matrix.arch != 'x64' }}
         run: |
-          docker run -d \
-            --env-file .devcontainer/.env \
-            -p 10000:10000 \
-            mcr.microsoft.com/azure-storage/azurite
+          make check
 
-          while ! curl $AZURE_STORAGE_ENDPOINT; do
-            echo "Waiting for $AZURE_STORAGE_ENDPOINT..."
-            sleep 1
-          done
-
-          # create container
-          az storage container create -n $AZURE_TEST_CONTAINER_NAME --connection-string $AZURE_STORAGE_CONNECTION_STRING
-          az storage container create -n ${AZURE_TEST_CONTAINER_NAME}2 --connection-string $AZURE_STORAGE_CONNECTION_STRING
-
-      - name: Start local web server for http(s) tests
+      - name: Run tests with coverage
+        if: ${{ env.PG_MAJOR == '17' && matrix.arch == 'x64' }}
         run: |
-          docker run -d \
-            --env-file .devcontainer/.env \
-            -p 8080:80 \
-            rclone/rclone serve webdav /data --addr :80
-
-          while ! curl $HTTP_ENDPOINT; do
-            echo "Waiting for $HTTP_ENDPOINT..."
-            sleep 1
-          done
-
-      - name: Start fake-gcs-server for Google Cloud Storage emulator tests
-        run: |
-          docker run -d \
-            --env-file .devcontainer/.env \
-            -p 4443:4443 \
-            tustvold/fake-gcs-server -scheme http -public-host localhost:4443
-
-          while ! curl $GOOGLE_SERVICE_ENDPOINT; do   
-            echo "Waiting for $GOOGLE_SERVICE_ENDPOINT..."
-            sleep 1
-          done
-
-          # create bucket
-          curl -v -X POST --data-binary "{\"name\":\"$GOOGLE_TEST_BUCKET\"}" -H "Content-Type: application/json" "$GOOGLE_SERVICE_ENDPOINT/storage/v1/b"
-          curl -v -X POST --data-binary "{\"name\":\"${GOOGLE_TEST_BUCKET}2\"}" -H "Content-Type: application/json" "$GOOGLE_SERVICE_ENDPOINT/storage/v1/b"
-
-      - name: Run tests
-        run: |
-          # Run tests with coverage tool
-          source <(cargo llvm-cov show-env --export-prefix)
-          cargo llvm-cov clean
-          cargo build --features "pg${{ env.PG_MAJOR }}, pg_test" --no-default-features
-          cargo pgrx test pg${{ env.PG_MAJOR }} --no-default-features
-          cargo llvm-cov report --lcov > lcov.info
+          make check-with-coverage
 
       - name: Upload coverage report to Codecov
-        if: ${{ env.PG_MAJOR }} == 17
+        if: ${{ env.PG_MAJOR == '17' && matrix.arch == 'x64' }}
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.xml
 lcov.info
 playground.rs
+*.env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,23 +91,28 @@ testing via `cargo pgrx test pg16`.
 
 # Testing
 
-We run `RUST_TEST_THREADS=1 cargo pgrx test` to run all our unit tests. If you
-run a specific test, you can do it via regex patterns like below:
-`cargo pgrx run pg17 test_numeric_*`.
+Object storage tests are integration tests which require below containers running locally:
+- minio container for s3
+- azurite container for azure blob storage
+- fake_gcs container for google cloud storage
+- webdav container for http(s) stores
 
-> [!WARNING]
-> Make sure to pass RUST_TEST_THREADS=1 as environment variable to `cargo pgrx test`.
+Our [Makefile](Makefile) automates setting up all containers and running tests for pg_parquet.
 
-Object storage tests are integration tests which require a storage emulator running
-locally. See [ci.yml](.github/workflows/ci.yml) to see how local storage emulators
-are started. You can also see the required environment variables from
-[.env file](.devcontainer/.env).
+#### Build Dependencies
+- rustup
+- pgrx
+- postgresql development deps
+
+#### Test Dependencies
+- docker
+- azure cli
+- pgaudit extension
 
 # Format and Lint
 
 We use `cargo-fmt` as formatter and `cargo-clippy` as linter. You can check
 how we run them from [ci.yml](.github/workflows/ci.yml).
-
 
 # Release
 

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,148 @@
-.PHONY: cargo-exists cargo-pgrx-exists pg_parquet install clean check uninstall
+.PHONY: init-pgrx build clean install uninstall package \
+	check check-with-coverage check-minio check-azure check-gcs check-http check-format check-lint \
+	start-containers stop-containers start-minio stop-minio start-azurite stop-azurite start-fake-gcs stop-fake-gcs start-web-dav stop-web-dav
+
+ENVFILE ?= .devcontainer/.env
+
+include $(ENVFILE)
+export
 
 PG_CONFIG ?= pg_config
 
-all: pg_parquet
+PG_MAJOR ?= $(shell $(PG_CONFIG) --version | cut -d '.' -f 1 | cut -d ' ' -f 2)
 
-cargo-exists:
-	   @which cargo > /dev/null || (echo "cargo is not available. Please install cargo." && exit 1)
+MINIO_IMAGE ?= minio/minio
+AZURITE_IMAGE ?= mcr.microsoft.com/azure-storage/azurite
+FAKE_GCS_IMAGE ?= tustvold/fake-gcs-server
+WEBDAV_IMAGE ?= rclone/rclone
 
-cargo-pgrx-exists: cargo-exists
-	   @which cargo-pgrx > /dev/null || (echo "cargo-pgrx is not available. Please install cargo-pgrx." && exit 1)
+all: build
 
-pg_parquet: cargo-pgrx-exists
-	   cargo build --release --features pg17
+init-pgrx:
+	cargo pgrx init --pg${PG_MAJOR} $(PG_CONFIG) --base-testing-port ${PGRX_TEST_PG_BASE_PORT}
 
-install: pg_parquet
-	   cargo pgrx install --release --features pg17
+build: init-pgrx
+	cargo build --release --features pg$(PG_MAJOR) --no-default-features
 
-clean: cargo-exists
-	   cargo clean
+clean:
+	cargo clean
 
-check: cargo-pgrx-exists
-	   RUST_TEST_THREADS=1 cargo pgrx test pg17
+install: build
+	cargo pgrx install --release --features pg$(PG_MAJOR) --no-default-features
 
 uninstall:
-	   rm -f $(shell $(PG_CONFIG) --pkglibdir)/pg_parquet.so
-	   rm -f $(shell $(PG_CONFIG) --sharedir)/extension/pg_parquet*
+	rm -f $(shell $(PG_CONFIG) --pkglibdir)/pg_parquet.so
+	rm -f $(shell $(PG_CONFIG) --sharedir)/extension/pg_parquet*
+
+package:
+	cargo pgrx package --profile release --features pg$(PG_MAJOR) --no-default-features
+
+check-format: init-pgrx
+	cargo fmt --all -- --check
+
+check-lint: init-pgrx
+	cargo clippy --all-targets --features "pg$(PG_MAJOR), pg_test" --no-default-features -- -D warnings
+
+check: build stop-containers start-containers
+	cargo pgrx test pg$(PG_MAJOR) --no-default-features
+
+check-with-coverage: init-pgrx stop-containers start-containers
+	cargo llvm-cov show-env --export-prefix > llvm-cov.env && \
+	. ./llvm-cov.env && \
+	cargo llvm-cov clean && \
+	cargo build --features "pg$(PG_MAJOR), pg_test" --no-default-features && \
+	cargo pgrx test pg$(PG_MAJOR) --no-default-features && \
+	cargo llvm-cov report --lcov > lcov.info
+
+check-s3: build stop-minio start-minio
+	cargo pgrx test pg$(PG_MAJOR) test_s3 --no-default-features
+
+check-azure: build stop-azurite start-azurite
+	cargo pgrx test pg$(PG_MAJOR) test_azure --no-default-features
+
+check-gcs: build stop-fake-gcs start-fake-gcs
+	cargo pgrx test pg$(PG_MAJOR) test_gcs --no-default-features
+
+check-http: build stop-web-dav start-web-dav
+	cargo pgrx test pg$(PG_MAJOR) test_http --no-default-features
+
+start-containers: start-minio start-azurite start-fake-gcs start-web-dav
+
+stop-containers: stop-minio stop-azurite stop-fake-gcs stop-web-dav
+
+start-minio:
+	docker run --rm -d \
+	  --name minio \
+	  --env-file $(ENVFILE) \
+	  -p 9000:9000 \
+	  --entrypoint "./entrypoint.sh" \
+	  --volume ./.devcontainer/minio-entrypoint.sh:/entrypoint.sh \
+	  $(MINIO_IMAGE)
+
+	while ! curl ${AWS_ENDPOINT_URL}; do \
+	  echo "Waiting for ${AWS_ENDPOINT_URL}..."; \
+	  sleep 1; \
+	done
+
+stop-minio:
+	docker stop minio || true
+
+start-azurite:
+	docker run --rm -d \
+	  --name azurite \
+	  --env-file $(ENVFILE) \
+	  -p 10000:10000 \
+	  $(AZURITE_IMAGE)
+
+	while ! curl ${AZURE_STORAGE_ENDPOINT}; do \
+	  echo "Waiting for ${AZURE_STORAGE_ENDPOINT}..."; \
+	  sleep 1; \
+	done
+
+	az storage container create -n ${AZURE_TEST_CONTAINER_NAME} --connection-string ${AZURE_STORAGE_CONNECTION_STRING}
+	az storage container create -n ${AZURE_TEST_CONTAINER_NAME}2 --connection-string ${AZURE_STORAGE_CONNECTION_STRING}
+
+stop-azurite:
+	docker stop azurite || true
+
+start-fake-gcs:
+	# tusvold/fake-gcs-server is not available for ARM64, so we build it from source
+	if [ "$(shell uname -m)" != "x86_64" ]; then \
+		rm -rf fake-gcs-server && \
+		git clone https://github.com/tustvold/fake-gcs-server.git && \
+		cd fake-gcs-server && git checkout support-xml-api && \
+		docker build . -t $(FAKE_GCS_IMAGE) && \
+		cd .. && rm -rf fake-gcs-server; \
+	fi
+
+	docker run --rm -d \
+		--name fake-gcs-server \
+		--env-file $(ENVFILE) \
+		-p 4443:4443 \
+		$(FAKE_GCS_IMAGE) -scheme http -public-host localhost:4443;
+
+	while ! curl ${GOOGLE_SERVICE_ENDPOINT}; do \
+	  echo "Waiting for ${GOOGLE_SERVICE_ENDPOINT}..."; \
+	  sleep 1; \
+	done
+
+	curl -v -X POST --data-binary "{\"name\":\"${GOOGLE_TEST_BUCKET}\"}" -H "Content-Type: application/json" "${GOOGLE_SERVICE_ENDPOINT}/storage/v1/b"
+	curl -v -X POST --data-binary "{\"name\":\"${GOOGLE_TEST_BUCKET}2\"}" -H "Content-Type: application/json" "${GOOGLE_SERVICE_ENDPOINT}/storage/v1/b"
+
+stop-fake-gcs:
+	docker stop fake-gcs-server || true
+
+start-web-dav:
+	docker run --rm -d \
+	  --name rclone-webdav \
+	  --env-file $(ENVFILE) \
+	  -p 8080:80 \
+	  $(WEBDAV_IMAGE) serve webdav /data --addr :80
+
+	while ! curl ${HTTP_ENDPOINT}; do \
+	  echo "Waiting for ${HTTP_ENDPOINT}..."; \
+	  sleep 1; \
+	done
+
+stop-web-dav:
+	docker stop rclone-webdav || true

--- a/src/parquet_copy_hook/copy_from_stdin.rs
+++ b/src/parquet_copy_hook/copy_from_stdin.rs
@@ -79,7 +79,7 @@ pub(crate) unsafe fn copy_stdin_to_file(uri_info: &ParsedUriInfo, natts: i16, is
 unsafe fn send_copy_in_begin(natts: i16, is_binary: bool) {
     let buf = makeStringInfo();
 
-    pq_beginmessage(buf, 'G' as _);
+    pq_beginmessage(buf, b'G' as _);
 
     let copy_format = if is_binary { 1 } else { 0 };
     pq_sendbyte(buf, copy_format);

--- a/src/parquet_copy_hook/copy_to_stdout.rs
+++ b/src/parquet_copy_hook/copy_to_stdout.rs
@@ -49,7 +49,7 @@ pub(crate) unsafe fn copy_file_to_stdout(uri_info: ParsedUriInfo, natts: i16) {
 unsafe fn send_copy_begin(natts: i16, is_binary: bool) {
     let buf = makeStringInfo();
 
-    pq_beginmessage(buf, 'H' as _);
+    pq_beginmessage(buf, b'H' as _);
 
     let copy_format = if is_binary { 1 } else { 0 };
     pq_sendbyte(buf, copy_format); /* overall format */
@@ -68,7 +68,7 @@ unsafe fn send_copy_begin(natts: i16, is_binary: bool) {
  * COPY .. TO STDOUT.
  */
 unsafe fn send_copy_end() {
-    pq_putemptymessage('c' as _);
+    pq_putemptymessage(b'c' as _);
 }
 
 /*
@@ -77,7 +77,7 @@ unsafe fn send_copy_end() {
 unsafe fn send_copy_data(data: &[u8]) {
     let buf = makeStringInfo();
 
-    pq_beginmessage(buf, 'd' as _);
+    pq_beginmessage(buf, b'd' as _);
     pq_sendbytes(buf, data.as_ptr() as _, data.len() as _);
     pq_endmessage(buf);
 }

--- a/src/pgrx_tests/object_store.rs
+++ b/src/pgrx_tests/object_store.rs
@@ -436,6 +436,15 @@ mod tests {
         std::env::remove_var("AZURE_STORAGE_ACCOUNT");
         std::env::remove_var("AZURE_STORAGE_KEY");
 
+        let unquoted_connection_string = std::env::var("AZURE_STORAGE_CONNECTION_STRING")
+            .unwrap()
+            .trim_matches('"')
+            .to_string();
+        std::env::set_var(
+            "AZURE_STORAGE_CONNECTION_STRING",
+            unquoted_connection_string,
+        );
+
         let test_container_name: String = std::env::var("AZURE_TEST_CONTAINER_NAME")
             .expect("AZURE_TEST_CONTAINER_NAME not found");
 


### PR DESCRIPTION
- [x] Automate spinning up test containers before running tests,
- [x] Use makefile targets in ci workflow,
- [x] Add arm64 ci workflow. (tusvold/fake-gcs-server image is built from source since tusvold/fake-gcs-server container does not work on arm64. already tried qemu but got random crashes)