### PR TITLE
Support "COPY FROM/TO PROGRAM '...' WITH (format parquet)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,6 +2528,7 @@ dependencies = [
  "cfg_aliases",
  "futures",
  "home",
+ "libc",
  "object_store",
  "once_cell",
  "parquet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ aws-credential-types = {version = "1", default-features = false}
 azure_storage = {version = "0.21", default-features = false}
 futures = "0.3"
 home = "0.5"
+libc = {version = "0.2", default-features = false }
 object_store = {version = "=0.12.2", default-features = false, features = ["aws", "azure", "fs", "gcp", "http"]}
 once_cell = "1"
 parquet = {version = "56", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ COPY table FROM 's3://mybucket/data.parquet' WITH (format 'parquet');
 ## Quick Reference
 - [Installation From Source](#installation-from-source)
 - [Usage](#usage)
-  - [Copy FROM/TO Parquet files TO/FROM Postgres tables](#copy-tofrom-parquet-files-fromto-postgres-tables)
+  - [Copy FROM/TO Parquet files TO/FROM Postgres tables](#copy-fromto-parquet-files-tofrom-postgres-tables)
+  - [COPY FROM/TO Parquet stdin/stdout TO/FROM Postgres tables)](#copy-fromto-parquet-stdinstdout-tofrom-postgres-tables)
+  - [COPY FROM/TO Parquet program stream TO/FROM Postgres tables)](#copy-fromto-parquet-program-stream-tofrom-postgres-tables)
   - [Inspect Parquet schema](#inspect-parquet-schema)
   - [Inspect Parquet metadata](#inspect-parquet-metadata)
   - [Inspect Parquet column statistics](#inspect-parquet-column-statistics)
@@ -64,11 +66,11 @@ psql> "CREATE EXTENSION pg_parquet;"
 
 ## Usage
 There are mainly 3 things that you can do with `pg_parquet`:
-1. You can export Postgres tables/queries to Parquet files,
+1. You can export Postgres tables/queries to Parquet files, stdin/stdout or a program's stream,
 2. You can ingest data from Parquet files to Postgres tables,
 3. You can inspect the schema and metadata of Parquet files.
 
-### COPY to/from Parquet files from/to Postgres tables
+### COPY from/to Parquet files to/from Postgres tables
 You can use PostgreSQL's `COPY` command to read and write from/to Parquet files. Below is an example of how to write a PostgreSQL table, with complex types, into a Parquet file and then to read the Parquet file content back into the same table.
 
 ```sql
@@ -107,7 +109,9 @@ COPY product_example FROM '/tmp/product_example.parquet';
 SELECT * FROM product_example;
 ```
 
-You can also use `COPY` command to read and write Parquet stream from/to standard input and output. Below is an example usage (you have to specify `format = parquet`):
+### COPY from/to Parquet stdin/stdout to/from Postgres tables
+
+You can use `COPY` command to read and write Parquet stream from/to standard input and output. Below is an example usage (you have to specify `format = parquet`):
 
 ```bash
 psql -d pg_parquet -p 28817 -h localhost -c "create table product_example_reconstructed (like product_example);"
@@ -116,6 +120,19 @@ psql -d pg_parquet -p 28817 -h localhost -c "create table product_example_recons
 psql -d pg_parquet -p 28817 -h localhost -c "copy product_example to stdout (format parquet);" | psql -d pg_parquet -p 28817 -h localhost -c "copy product_example_reconstructed from stdin (format parquet);"
  COPY 2
 ```
+
+### COPY from/to Parquet program stream to/from Postgres tables
+
+You can use `COPY` command to read and write Parquet stream from/to a program's input and output. Below is an example usage (you have to specify `format = parquet`):
+
+```bash
+psql -d pg_parquet -p 28817 -h localhost -c "copy product_example_reconstructed to program 'cat > /tmp/test.parquet' (format parquet);"
+ COPY 2
+
+psql -d pg_parquet -p 28817 -h localhost -c "copy product_example_reconstructed from program 'cat /tmp/test.parquet' (format parquet);"
+ COPY 2
+```
+
 
 ### Inspect Parquet schema
 You can call `SELECT * FROM parquet.schema(<uri>)` to discover the schema of the Parquet file at given uri.

--- a/src/arrow_parquet/uri_utils.rs
+++ b/src/arrow_parquet/uri_utils.rs
@@ -40,10 +40,21 @@ pub(crate) struct ParsedUriInfo {
     pub(crate) path: Path,
     pub(crate) scheme: ObjectStoreScheme,
     pub(crate) stdio_tmp_fd: Option<i32>,
+    pub(crate) program: Option<*mut c_char>,
 }
 
 impl ParsedUriInfo {
     pub(crate) fn for_std_inout() -> Self {
+        Self::create_tmp_file()
+    }
+
+    pub(crate) fn for_program(program: *mut c_char) -> Self {
+        let mut uri_info = Self::create_tmp_file();
+        uri_info.program = Some(program);
+        uri_info
+    }
+
+    fn create_tmp_file() -> Self {
         // open temp postgres file, which is removed after transaction ends
         let tmp_path_fd = unsafe { OpenTemporaryFile(false) };
 
@@ -129,6 +140,7 @@ impl TryFrom<&str> for ParsedUriInfo {
             path,
             scheme,
             stdio_tmp_fd: None,
+            program: None,
         })
     }
 }

--- a/src/parquet_copy_hook.rs
+++ b/src/parquet_copy_hook.rs
@@ -1,4 +1,5 @@
 pub(crate) mod copy_from;
+pub(crate) mod copy_from_program;
 pub(crate) mod copy_from_stdin;
 pub(crate) mod copy_to;
 pub(crate) mod copy_to_dest_receiver;

--- a/src/parquet_copy_hook.rs
+++ b/src/parquet_copy_hook.rs
@@ -2,6 +2,7 @@ pub(crate) mod copy_from;
 pub(crate) mod copy_from_stdin;
 pub(crate) mod copy_to;
 pub(crate) mod copy_to_dest_receiver;
+pub(crate) mod copy_to_program;
 pub(crate) mod copy_to_split_dest_receiver;
 pub(crate) mod copy_to_stdout;
 pub(crate) mod copy_utils;

--- a/src/parquet_copy_hook/copy_from.rs
+++ b/src/parquet_copy_hook/copy_from.rs
@@ -13,8 +13,11 @@ use pgrx::{
 
 use crate::{
     arrow_parquet::{parquet_reader::ParquetReaderContext, uri_utils::ParsedUriInfo},
-    parquet_copy_hook::copy_utils::{
-        copy_from_stmt_create_option_list, copy_stmt_lock_mode, copy_stmt_relation_oid,
+    parquet_copy_hook::{
+        copy_from_program::copy_program_to_file,
+        copy_utils::{
+            copy_from_stmt_create_option_list, copy_stmt_lock_mode, copy_stmt_relation_oid,
+        },
     },
 };
 
@@ -146,7 +149,9 @@ pub(crate) fn execute_copy_from(
     let match_by = copy_from_stmt_match_by(p_stmt);
 
     unsafe {
-        if uri_info.stdio_tmp_fd.is_some() {
+        if uri_info.program.is_some() {
+            copy_program_to_file(uri_info);
+        } else if uri_info.stdio_tmp_fd.is_some() {
             let is_binary = true;
             copy_stdin_to_file(uri_info, tupledesc.natts as _, is_binary);
         }

--- a/src/parquet_copy_hook/copy_from.rs
+++ b/src/parquet_copy_hook/copy_from.rs
@@ -16,7 +16,8 @@ use crate::{
     parquet_copy_hook::{
         copy_from_program::copy_program_to_file,
         copy_utils::{
-            copy_from_stmt_create_option_list, copy_stmt_lock_mode, copy_stmt_relation_oid,
+            copy_from_stmt_create_option_list, copy_stmt_is_std_inout, copy_stmt_lock_mode,
+            copy_stmt_program, copy_stmt_relation_oid,
         },
     },
 };
@@ -120,7 +121,7 @@ pub(crate) fn execute_copy_from(
     p_stmt: &PgBox<PlannedStmt>,
     query_string: &CStr,
     query_env: &PgBox<QueryEnvironment>,
-    uri_info: &ParsedUriInfo,
+    mut uri_info: ParsedUriInfo,
 ) -> u64 {
     let rel_oid = copy_stmt_relation_oid(p_stmt);
 
@@ -149,15 +150,15 @@ pub(crate) fn execute_copy_from(
     let match_by = copy_from_stmt_match_by(p_stmt);
 
     unsafe {
-        if uri_info.program.is_some() {
-            copy_program_to_file(uri_info);
-        } else if uri_info.stdio_tmp_fd.is_some() {
+        if let Some(program) = copy_stmt_program(p_stmt) {
+            copy_program_to_file(&mut uri_info, &program);
+        } else if copy_stmt_is_std_inout(p_stmt) {
             let is_binary = true;
-            copy_stdin_to_file(uri_info, tupledesc.natts as _, is_binary);
+            copy_stdin_to_file(&uri_info, tupledesc.natts as _, is_binary);
         }
 
         // parquet reader context is used throughout the COPY FROM operation.
-        let parquet_reader_context = ParquetReaderContext::new(uri_info, match_by, &tupledesc);
+        let parquet_reader_context = ParquetReaderContext::new(&uri_info, match_by, &tupledesc);
         push_parquet_reader_context(parquet_reader_context);
 
         // makes sure to set binary format

--- a/src/parquet_copy_hook/copy_from_program.rs
+++ b/src/parquet_copy_hook/copy_from_program.rs
@@ -1,0 +1,47 @@
+use std::{ffi::CStr, io::pipe, process::Command};
+
+use crate::arrow_parquet::uri_utils::{uri_as_string, ParsedUriInfo};
+
+pub(crate) unsafe fn copy_program_to_file(uri_info: &ParsedUriInfo) {
+    let program = CStr::from_ptr(uri_info.program.expect("Program pointer is null"))
+        .to_str()
+        .unwrap_or_else(|e| panic!("Failed to convert program pointer to string: {e}"))
+        .to_string();
+
+    let (mut pipe_in, pipe_out) =
+        pipe().unwrap_or_else(|e| panic!("Failed to create command pipe: {e}"));
+
+    #[cfg(unix)]
+    let mut command = Command::new("/bin/sh")
+        .arg("-lc")
+        .arg(program)
+        .stdout(pipe_out)
+        .spawn()
+        .unwrap_or_else(|e| panic!("Failed to spawn command: {e}"));
+
+    #[cfg(windows)]
+    let mut command = Command::new("cmd")
+        .arg("/C")
+        .arg(program)
+        .stdout(pipe_out)
+        .spawn()
+        .unwrap_or_else(|e| panic!("Failed to spawn command: {e}"));
+
+    command
+        .wait()
+        .unwrap_or_else(|e| panic!("Failed to wait for command: {e}"));
+
+    // Write input pipe to the file
+    let path = uri_as_string(&uri_info.uri);
+
+    // create or overwrite the local file
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(&path)
+        .unwrap_or_else(|e| panic!("{}", e));
+
+    std::io::copy(&mut pipe_in, &mut file)
+        .unwrap_or_else(|e| panic!("Failed to copy command stdout to file: {e}"));
+}

--- a/src/parquet_copy_hook/copy_to_program.rs
+++ b/src/parquet_copy_hook/copy_to_program.rs
@@ -1,48 +1,20 @@
-use std::{
-    ffi::{c_char, CStr},
-    fs::File,
-    io::pipe,
-    process::Command,
-};
+use std::fs::File;
 
 use crate::arrow_parquet::uri_utils::{uri_as_string, ParsedUriInfo};
 
-pub(crate) unsafe fn copy_file_to_program(uri_info: ParsedUriInfo, program: *mut c_char) {
-    let (pipe_in, mut pipe_out) =
-        pipe().unwrap_or_else(|e| panic!("Failed to create command pipe: {e}"));
-
-    let program = CStr::from_ptr(program).to_string_lossy().into_owned();
-
-    #[cfg(unix)]
-    let mut command = Command::new("/bin/sh")
-        .arg("-lc")
-        .arg(program)
-        .stdin(pipe_in)
-        .spawn()
-        .unwrap_or_else(|e| panic!("Failed to spawn command: {e}"));
-
-    #[cfg(windows)]
-    let mut command = Command::new("cmd")
-        .arg("/C")
-        .arg(program)
-        .stdin(pipe_in)
-        .spawn()
-        .unwrap_or_else(|e| panic!("Failed to spawn command: {e}"));
-
-    // Write the file to output pipe
+pub(crate) unsafe fn copy_file_to_program(uri_info: &mut ParsedUriInfo, program: &str) {
+    // get tmp file
     let path = uri_as_string(&uri_info.uri);
 
     let mut file = File::open(path).unwrap_or_else(|e| {
         panic!("could not open temp file: {e}");
     });
 
-    std::io::copy(&mut file, &mut pipe_out)
+    // open and then get pipe file
+    let copy_from = false;
+    let mut pipe_file = uri_info.open_program_pipe(program, copy_from);
+
+    // Write temp file to pipe file
+    std::io::copy(&mut file, &mut pipe_file)
         .unwrap_or_else(|e| panic!("Failed to copy file to command stdin: {e}"));
-
-    // close output pipe to unblock the command
-    drop(pipe_out);
-
-    command
-        .wait()
-        .unwrap_or_else(|e| panic!("Failed to wait for command: {e}"));
 }

--- a/src/parquet_copy_hook/copy_to_program.rs
+++ b/src/parquet_copy_hook/copy_to_program.rs
@@ -1,0 +1,48 @@
+use std::{
+    ffi::{c_char, CStr},
+    fs::File,
+    io::pipe,
+    process::Command,
+};
+
+use crate::arrow_parquet::uri_utils::{uri_as_string, ParsedUriInfo};
+
+pub(crate) unsafe fn copy_file_to_program(uri_info: ParsedUriInfo, program: *mut c_char) {
+    let (pipe_in, mut pipe_out) =
+        pipe().unwrap_or_else(|e| panic!("Failed to create command pipe: {e}"));
+
+    let program = CStr::from_ptr(program).to_string_lossy().into_owned();
+
+    #[cfg(unix)]
+    let mut command = Command::new("/bin/sh")
+        .arg("-lc")
+        .arg(program)
+        .stdin(pipe_in)
+        .spawn()
+        .unwrap_or_else(|e| panic!("Failed to spawn command: {e}"));
+
+    #[cfg(windows)]
+    let mut command = Command::new("cmd")
+        .arg("/C")
+        .arg(program)
+        .stdin(pipe_in)
+        .spawn()
+        .unwrap_or_else(|e| panic!("Failed to spawn command: {e}"));
+
+    // Write the file to output pipe
+    let path = uri_as_string(&uri_info.uri);
+
+    let mut file = File::open(path).unwrap_or_else(|e| {
+        panic!("could not open temp file: {e}");
+    });
+
+    std::io::copy(&mut file, &mut pipe_out)
+        .unwrap_or_else(|e| panic!("Failed to copy file to command stdin: {e}"));
+
+    // close output pipe to unblock the command
+    drop(pipe_out);
+
+    command
+        .wait()
+        .unwrap_or_else(|e| panic!("Failed to wait for command: {e}"));
+}

--- a/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
+++ b/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
@@ -23,8 +23,8 @@ pub(crate) const INVALID_FILE_SIZE_BYTES: i64 = 0;
 struct CopyToParquetSplitDestReceiver {
     dest: DestReceiver,
     uri: *const c_char,
-    is_to_stdout: bool,
     program: *mut c_char,
+    is_to_stdout: bool,
     tupledesc: TupleDesc,
     operation: i32,
     options: CopyToParquetOptions,
@@ -50,8 +50,8 @@ impl CopyToParquetSplitDestReceiver {
         let child_uri = self.create_uri_for_child();
         self.current_child_receiver = create_copy_to_parquet_dest_receiver(
             child_uri,
-            self.is_to_stdout,
             self.program,
+            self.is_to_stdout,
             self.options,
         );
         self.current_child_id += 1;
@@ -212,8 +212,8 @@ extern "C-unwind" fn copy_split_destroy(_dest: *mut DestReceiver) {}
 #[allow(clippy::too_many_arguments)]
 pub extern "C-unwind" fn create_copy_to_parquet_split_dest_receiver(
     uri: *const c_char,
-    is_to_stdout: bool,
     program: *mut c_char,
+    is_to_stdout: bool,
     file_size_bytes: *const i64,
     field_ids: *const c_char,
     row_group_size: *const i64,

--- a/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
+++ b/src/parquet_copy_hook/copy_to_split_dest_receiver.rs
@@ -24,6 +24,7 @@ struct CopyToParquetSplitDestReceiver {
     dest: DestReceiver,
     uri: *const c_char,
     is_to_stdout: bool,
+    program: *mut c_char,
     tupledesc: TupleDesc,
     operation: i32,
     options: CopyToParquetOptions,
@@ -47,8 +48,12 @@ impl CopyToParquetSplitDestReceiver {
     fn create_new_child(&mut self) {
         // create a new child receiver
         let child_uri = self.create_uri_for_child();
-        self.current_child_receiver =
-            create_copy_to_parquet_dest_receiver(child_uri, self.is_to_stdout, self.options);
+        self.current_child_receiver = create_copy_to_parquet_dest_receiver(
+            child_uri,
+            self.is_to_stdout,
+            self.program,
+            self.options,
+        );
         self.current_child_id += 1;
 
         // start the child receiver
@@ -208,6 +213,7 @@ extern "C-unwind" fn copy_split_destroy(_dest: *mut DestReceiver) {}
 pub extern "C-unwind" fn create_copy_to_parquet_split_dest_receiver(
     uri: *const c_char,
     is_to_stdout: bool,
+    program: *mut c_char,
     file_size_bytes: *const i64,
     field_ids: *const c_char,
     row_group_size: *const i64,
@@ -280,6 +286,7 @@ pub extern "C-unwind" fn create_copy_to_parquet_split_dest_receiver(
     split_dest.dest.mydest = CommandDest::DestCopyOut;
     split_dest.uri = uri;
     split_dest.is_to_stdout = is_to_stdout;
+    split_dest.program = program;
     split_dest.tupledesc = std::ptr::null_mut();
     split_dest.operation = -1;
     split_dest.options = options;

--- a/src/parquet_copy_hook/copy_utils.rs
+++ b/src/parquet_copy_hook/copy_utils.rs
@@ -222,7 +222,7 @@ pub(crate) fn copy_stmt_uri(p_stmt: &PgBox<PlannedStmt>) -> Result<ParsedUriInfo
     let copy_stmt = unsafe { PgBox::<CopyStmt>::from_pg(p_stmt.utilityStmt as _) };
 
     if copy_stmt.is_program {
-        return Err("program is not supported".to_string());
+        return Ok(ParsedUriInfo::for_program(copy_stmt.filename));
     }
 
     if copy_stmt.filename.is_null() {
@@ -420,10 +420,6 @@ fn is_copy_parquet_stmt(p_stmt: &PgBox<PlannedStmt>, copy_from: bool) -> bool {
     let copy_stmt = unsafe { PgBox::<CopyStmt>::from_pg(p_stmt.utilityStmt as _) };
 
     if copy_from != copy_stmt.is_from {
-        return false;
-    }
-
-    if copy_stmt.is_program {
         return false;
     }
 

--- a/src/parquet_copy_hook/copy_utils.rs
+++ b/src/parquet_copy_hook/copy_utils.rs
@@ -222,7 +222,7 @@ pub(crate) fn copy_stmt_uri(p_stmt: &PgBox<PlannedStmt>) -> Result<ParsedUriInfo
     let copy_stmt = unsafe { PgBox::<CopyStmt>::from_pg(p_stmt.utilityStmt as _) };
 
     if copy_stmt.is_program {
-        return Ok(ParsedUriInfo::for_program(copy_stmt.filename));
+        return Ok(ParsedUriInfo::for_program());
     }
 
     if copy_stmt.filename.is_null() {
@@ -236,6 +236,28 @@ pub(crate) fn copy_stmt_uri(p_stmt: &PgBox<PlannedStmt>) -> Result<ParsedUriInfo
     };
 
     ParsedUriInfo::try_from(uri)
+}
+
+pub(crate) fn copy_stmt_program(p_stmt: &PgBox<PlannedStmt>) -> Option<String> {
+    let copy_stmt = unsafe { PgBox::<CopyStmt>::from_pg(p_stmt.utilityStmt as _) };
+
+    if copy_stmt.is_program {
+        let program = unsafe {
+            CStr::from_ptr(copy_stmt.filename)
+                .to_str()
+                .expect("program option is not a valid CString")
+        };
+
+        Some(program.to_string())
+    } else {
+        None
+    }
+}
+
+pub(crate) fn copy_stmt_is_std_inout(p_stmt: &PgBox<PlannedStmt>) -> bool {
+    let copy_stmt = unsafe { PgBox::<CopyStmt>::from_pg(p_stmt.utilityStmt as _) };
+
+    copy_stmt.filename.is_null() && !copy_stmt.is_program
 }
 
 pub(crate) fn copy_to_stmt_file_size_bytes(p_stmt: &PgBox<PlannedStmt>) -> i64 {

--- a/src/parquet_copy_hook/hook.rs
+++ b/src/parquet_copy_hook/hook.rs
@@ -69,6 +69,7 @@ fn process_copy_to_parquet(
     let parquet_split_dest = create_copy_to_parquet_split_dest_receiver(
         uri_as_string(&uri_info.uri).as_pg_cstr(),
         uri_info.stdio_tmp_fd.is_some(),
+        uri_info.program.unwrap_or_default(),
         &file_size_bytes,
         field_ids,
         &row_group_size,

--- a/src/parquet_copy_hook/hook.rs
+++ b/src/parquet_copy_hook/hook.rs
@@ -13,8 +13,9 @@ use crate::{
     },
     create_copy_to_parquet_split_dest_receiver,
     parquet_copy_hook::copy_utils::{
-        copy_stmt_uri, copy_to_stmt_compression_level, copy_to_stmt_row_group_size,
-        copy_to_stmt_row_group_size_bytes, is_copy_from_parquet_stmt, is_copy_to_parquet_stmt,
+        copy_stmt_is_std_inout, copy_stmt_program, copy_stmt_uri, copy_to_stmt_compression_level,
+        copy_to_stmt_row_group_size, copy_to_stmt_row_group_size_bytes, is_copy_from_parquet_stmt,
+        is_copy_to_parquet_stmt,
     },
 };
 
@@ -53,6 +54,14 @@ fn process_copy_to_parquet(
 ) -> u64 {
     let uri_info = copy_stmt_uri(p_stmt).unwrap_or_else(|e| panic!("{}", e));
 
+    let program = if let Some(program) = copy_stmt_program(p_stmt) {
+        program.as_pg_cstr()
+    } else {
+        std::ptr::null_mut()
+    };
+
+    let is_std_inout = copy_stmt_is_std_inout(p_stmt);
+
     let copy_from = false;
     ensure_access_privilege_to_uri(&uri_info, copy_from);
 
@@ -68,8 +77,8 @@ fn process_copy_to_parquet(
 
     let parquet_split_dest = create_copy_to_parquet_split_dest_receiver(
         uri_as_string(&uri_info.uri).as_pg_cstr(),
-        uri_info.stdio_tmp_fd.is_some(),
-        uri_info.program.unwrap_or_default(),
+        program,
+        is_std_inout,
         &file_size_bytes,
         field_ids,
         &row_group_size,
@@ -109,7 +118,7 @@ fn process_copy_from_parquet(
 
     validate_copy_from_options(p_stmt);
 
-    PgTryBuilder::new(|| execute_copy_from(p_stmt, query_string, query_env, &uri_info))
+    PgTryBuilder::new(|| execute_copy_from(p_stmt, query_string, query_env, uri_info))
         .catch_others(|cause| {
             // make sure to pop the parquet reader context
             // In case we did not push the context, we should not throw an error while popping

--- a/src/pgrx_tests/copy_program.rs
+++ b/src/pgrx_tests/copy_program.rs
@@ -1,0 +1,287 @@
+#[pgrx::pg_schema]
+mod tests {
+    use std::io::pipe;
+    use std::io::Read;
+    use std::io::Write;
+    use std::process::Command;
+    use std::vec;
+
+    use pgrx::pg_test;
+    use pgrx::Spi;
+
+    use crate::pgrx_tests::common::LOCAL_TEST_FILE_PATH;
+
+    #[pg_test]
+    fn test_copy_program() {
+        let pg_version = std::env::var("PG_MAJOR").unwrap().parse::<i32>().unwrap();
+
+        let test_base_port = std::env::var("PGRX_TEST_PG_BASE_PORT")
+            .unwrap()
+            .parse::<i32>()
+            .unwrap();
+
+        let test_port = (test_base_port + pg_version).to_string();
+
+        // create test_expected
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg("CREATE TABLE test_expected (a int, b int generated always as (a + 2) stored);")
+            .output()
+            .expect("failed to execute process");
+        assert!(
+            output.status.success(),
+            "Failed to create test_expected table"
+        );
+
+        // create test_result
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg("CREATE TABLE test_result (a int, b int);")
+            .output()
+            .expect("failed to execute process");
+        assert!(
+            output.status.success(),
+            "Failed to create test_result table"
+        );
+
+        // insert data into test_expected
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(
+                "INSERT INTO test_expected SELECT i FROM generate_series(1, 3) i;
+                  INSERT INTO test_expected VALUES (NULL);",
+            )
+            .output()
+            .expect("failed to execute process");
+        assert!(
+            output.status.success(),
+            "Failed to insert into test_expected table"
+        );
+
+        // create a dummy role
+        let role = "dummy";
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(format!(
+                "DROP ROLE IF EXISTS {role};
+                 CREATE ROLE {role} LOGIN;
+                 GRANT SELECT, INSERT, UPDATE, DELETE ON test_expected TO {role};
+                 GRANT SELECT, INSERT, UPDATE, DELETE ON test_result TO {role};"
+            ))
+            .output()
+            .expect("failed to execute process");
+        assert!(output.status.success(), "Failed to create role {role}");
+
+        // try copy to without pg_execute_server_program permission
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-U")
+            .arg(role)
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(format!(
+                "COPY test_expected TO PROGRAM 'cat > {LOCAL_TEST_FILE_PATH}' WITH (format parquet);"
+            ))
+            .output().expect("failed to execute process");
+        assert!(
+            !output.status.success(),
+            "Copy to PROGRAM should fail without permission"
+        );
+        assert!(String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("pg_execute_server_program"));
+
+        // try copy from without pg_execute_server_program permission
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-U")
+            .arg(role)
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(format!(
+                "COPY test_result FROM PROGRAM 'cat {LOCAL_TEST_FILE_PATH}' WITH (format parquet);"
+            ))
+            .output()
+            .expect("failed to execute process");
+        assert!(
+            !output.status.success(),
+            "Copy from PROGRAM should fail without permission"
+        );
+        assert!(String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("pg_execute_server_program"));
+
+        // grant pg_execute_server_program permission
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(format!("GRANT pg_execute_server_program TO {role};"))
+            .output()
+            .expect("failed to execute process");
+        assert!(
+            output.status.success(),
+            "Failed to grant pg_execute_server_program permission"
+        );
+
+        // copy to program with dummy role
+        let (mut pipe_in, pipe_out) = pipe().expect("Failed to create pipe");
+        let mut copy_to = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-U")
+            .arg(role)
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(format!("COPY test_expected TO PROGRAM 'cat > {LOCAL_TEST_FILE_PATH}' WITH (format parquet);"))
+            .stdout(pipe_out)
+            .spawn()
+            .expect("failed to execute process");
+
+        let mut buffer = Vec::new();
+        {
+            pipe_in
+                .read_to_end(&mut buffer)
+                .expect("Failed to read from input pipe");
+
+            let status = copy_to.wait().expect("Failed to wait for 'copy_to'");
+            assert!(status.success(), "psql COPY TO process did not succeed");
+        }
+
+        // copy from program with dummy role
+        let (pipe_in, mut pipe_out) = pipe().expect("Failed to create pipe");
+        let mut copy_from = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-U")
+            .arg(role)
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(format!(
+                "COPY test_result FROM PROGRAM 'cat {LOCAL_TEST_FILE_PATH}' WITH (format parquet);"
+            ))
+            .stdin(pipe_in)
+            .spawn()
+            .expect("failed to execute process");
+
+        {
+            // Write the data we just read to the pipe's output
+            pipe_out
+                .write_all(&buffer)
+                .expect("Failed to write to pipe");
+            pipe_out.flush().expect("Failed to flush pipe");
+
+            let status = copy_from.wait().expect("Failed to wait for 'copy_from'");
+            assert!(status.success(), "psql COPY FROM process did not succeed");
+        }
+
+        // write to a file (this is needed because Spi::run cannot see external transactions)
+        let mut copy_to_file = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(format!(
+                "COPY test_result TO '{LOCAL_TEST_FILE_PATH}' with (format parquet);"
+            ))
+            .spawn()
+            .expect("failed to execute process");
+
+        let status = copy_to_file
+            .wait()
+            .expect("Failed to wait for 'copy_to_file'");
+        assert!(
+            status.success(),
+            "psql COPY TO FILE process did not succeed"
+        );
+
+        // assert table data
+        Spi::run("create temp table test_tmp (a int, b int);").unwrap();
+        Spi::run(format!("copy test_tmp from '{LOCAL_TEST_FILE_PATH}';").as_str()).unwrap();
+
+        let select_command = "SELECT * FROM test_tmp ORDER BY 1,2;";
+        let result = Spi::connect(|client| {
+            let mut results = Vec::new();
+            let tup_table = client.select(select_command, None, &[]).unwrap();
+
+            for row in tup_table {
+                let a = row["a"].value().unwrap();
+                let b = row["b"].value().unwrap();
+                results.push((a, b));
+            }
+
+            results
+        });
+
+        assert_eq!(
+            result,
+            [
+                (Some(1), Some(3)),
+                (Some(2), Some(4)),
+                (Some(3), Some(5)),
+                (None, None),
+            ]
+        );
+
+        // drop tables and role
+        let output = Command::new("psql")
+            .arg("-p")
+            .arg(test_port.clone())
+            .arg("-h")
+            .arg("localhost")
+            .arg("-d")
+            .arg("pgrx_tests")
+            .arg("-c")
+            .arg(format!(
+                "DROP TABLE test_expected, test_result; DROP ROLE {role};"
+            ))
+            .output()
+            .expect("failed to execute process");
+        assert!(output.status.success(), "Failed to clean up");
+    }
+}

--- a/src/pgrx_tests/mod.rs
+++ b/src/pgrx_tests/mod.rs
@@ -2,6 +2,7 @@ mod common;
 mod copy_from_coerce;
 mod copy_options;
 mod copy_pg_rules;
+mod copy_program;
 mod copy_stdin_out;
 mod copy_type_roundtrip;
 mod gucs;


### PR DESCRIPTION
Now it is possible to use programs with `COPY table TO/FROM PROGRAM '...' WITH (format parquet)` syntax.

e.g.
```sql
pg_parquet=# CREATE TABLE test_table(a int);
CREATE TABLE

pg_parquet=# INSERT INTO test_table SELECT i FROM generate_series(1,10) i;
INSERT 0 10

pg_parquet=# COPY test_table TO PROGRAM 'cat > /tmp/test.parquet' WITH (format parquet);
COPY 10

pg_parquet=# COPY test_table FROM PROGRAM 'cat /tmp/test.parquet' WITH (format parquet);
COPY 10
```

Similar to how we support `COPY TO/FROM stdin/stdout WITH(format parquet)`, we use a temp file as intermediate file and finally we copy from/to program's stdout/stdin by piping the temp file.

Closes #147.