### PR TITLE
explicitly require pg_parquet in shared_preload_libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,23 @@ After installing `Postgres`, you need to set up `rustup`, `cargo-pgrx` to build 
 # install rustup
 > curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
+# set cargo-pgrx (should be the same as pgrx dep in Cargo.toml) and pg versions
+> export CARGO_PGRX_VERSION=0.15.0
+> export PG_MAJOR=17
+
 # install cargo-pgrx
-> cargo install cargo-pgrx
+> cargo install --force --locked cargo-pgrx@"${CARGO_PGRX_VERSION}"
 
 # configure pgrx
-> cargo pgrx init --pg17 $(which pg_config)
+> cargo pgrx init --pg"${PG_MAJOR}" $(which pg_config)
 
-# append the extension to shared_preload_libraries in ~/.pgrx/data-17/postgresql.conf 
-> echo "shared_preload_libraries = 'pg_parquet'" >> ~/.pgrx/data-17/postgresql.conf
+# append the extension to shared_preload_libraries 
+> echo "shared_preload_libraries = 'pg_parquet'" >> ~/.pgrx/data-"${PG_MAJOR}"/postgresql.conf
 
 # initialize a data directory, build and install the extension (to the targets specified by configured pg_config), then connects to a session
-> cargo pgrx run
+> cargo pgrx run --features pg"${PG_MAJOR}"
 # alternatively you can only build and install the extension (pass --release flag for production binary)
-> cargo pgrx install --release
+> cargo pgrx install --release --features pg"${PG_MAJOR}"
 
 # create the extension in the database
 psql> "CREATE EXTENSION pg_parquet;"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,10 @@ pub(crate) static PG_BACKEND_TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(||
 
 #[pg_guard]
 pub extern "C-unwind" fn _PG_init() {
+    if !unsafe { pgrx::pg_sys::process_shared_preload_libraries_in_progress } {
+        panic!("pg_parquet must be loaded via shared_preload_libraries. Add 'pg_parquet' to shared_preload_libraries in postgresql.conf and restart Postgres.");
+    }
+
     unsafe {
         GucRegistry::define_bool_guc(
             CStr::from_ptr("pg_parquet.enable_copy_hooks".as_pg_cstr()),


### PR DESCRIPTION
- [x] Explicitly require pg_parquet in shared_preload_libraries because we hook into Postgres utility hook,
- [x] Improve README.md about installation.
   - specify `--features pg<version>` if the pg version is not the latest supported (default) by pg_parquet.
   - specify `cargo-pgrx version` as the same as `pgrx` dependency in Cargo.toml.

Closes #68.
Closes #149.