### PR TITLE
Use session variables to set object store credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,19 @@ $ cat ~/.aws/config
 region = eu-central-1
 ```
 
-Alternatively, you can use the following environment variables when starting postgres to configure the S3 client:
+Alternatively, you can configure AWS credentials using session variables (GUCs) or environment variables:
+
+#### Session Variables (GUCs) - Highest Priority
+You can set these within a PostgreSQL session:
+```sql
+SET pg_parquet.aws_access_key_id = 'AKIA...';
+SET pg_parquet.aws_secret_access_key = '...';
+SET pg_parquet.aws_session_token = '...';  -- Optional, for temporary credentials
+SET pg_parquet.aws_region = 'us-east-1';
+SET pg_parquet.aws_endpoint_url = 'https://s3.amazonaws.com';
+```
+
+#### Environment Variables - Second Priority
 - `AWS_ACCESS_KEY_ID`: the access key ID of the AWS account
 - `AWS_SECRET_ACCESS_KEY`: the secret access key of the AWS account
 - `AWS_SESSION_TOKEN`: the session token for the AWS account
@@ -234,8 +246,9 @@ Alternatively, you can use the following environment variables when starting pos
 - `AWS_ALLOW_HTTP`: allows http endpoints **(only via environment variables)**
 
 Config source priority order is shown below:
-1. Environment variables,
-2. Config file.
+1. Session variables (GUCs),
+2. Environment variables,
+3. Config file.
 
 Supported S3 uri formats are shown below:
 - s3:// \<bucket\> / \<path\>
@@ -304,9 +317,35 @@ $ cat ~/.config/gcloud/application_default_credentials.json
 }
 ```
 
-Alternatively, you can use the following environment variables when starting postgres to configure the Google Cloud Storage client:
+Alternatively, you can configure Google Cloud Storage credentials using session variables (GUCs) or environment variables:
+
+#### Session Variables (GUCs) - Highest Priority
+You can set these within a PostgreSQL session:
+
+**For service account key (JSON string):**
+```sql
+-- Simple JSON (escape single quotes by doubling them)
+SET pg_parquet.google_service_account_key = '{"type": "service_account", "project_id": "my-project"}';
+
+-- Complex JSON with private key (escape single quotes)
+SET pg_parquet.google_service_account_key = '{"type": "service_account", "project_id": "my-project", "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n", "client_email": "service@my-project.iam.gserviceaccount.com"}';
+```
+
+**For service account path:**
+```sql
+SET pg_parquet.google_service_account_path = '/path/to/service-account-key.json';
+```
+
+**Note:** When setting JSON service account keys via GUC, make sure to escape any single quotes (`'`) by doubling them (`''`).
+
+#### Environment Variables - Second Priority
 - `GOOGLE_SERVICE_ACCOUNT_KEY`: json serialized service account key **(only via environment variables)**
 - `GOOGLE_SERVICE_ACCOUNT_PATH`: an alternative location for the config file **(only via environment variables)**
+
+Config source priority order is shown below:
+1. Session variables (GUCs),
+2. Environment variables,
+3. Default credentials file (`~/.config/gcloud/application_default_credentials.json`).
 
 Supported Google Cloud Storage uri formats are shown below:
 - gs:// \<bucket\> / \<path\>

--- a/src/object_store/aws.rs
+++ b/src/object_store/aws.rs
@@ -5,7 +5,10 @@ use aws_credential_types::provider::ProvideCredentials;
 use object_store::aws::AmazonS3Builder;
 use url::Url;
 
-use crate::PG_BACKEND_TOKIO_RUNTIME;
+use crate::{
+    AWS_ACCESS_KEY_ID, AWS_ENDPOINT_URL, AWS_REGION, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN,
+    PG_BACKEND_TOKIO_RUNTIME,
+};
 
 use super::object_store_cache::ObjectStoreWithExpiration;
 
@@ -115,7 +118,7 @@ struct AwsS3Config {
 }
 
 impl AwsS3Config {
-    // load reads the s3 config from the environment variables first and config files as fallback.
+    // load reads the s3 config from GUCs first, then environment variables, then config files as fallback.
     fn load() -> Self {
         let allow_http = if let Ok(allow_http) = std::env::var("AWS_ALLOW_HTTP") {
             allow_http.parse().unwrap_or(false)
@@ -123,35 +126,66 @@ impl AwsS3Config {
             false
         };
 
-        // first tries environment variables and then the config files
-        let sdk_config = PG_BACKEND_TOKIO_RUNTIME
-            .block_on(async { aws_config::defaults(BehaviorVersion::latest()).load().await });
-
-        let mut access_key_id = None;
-        let mut secret_access_key = None;
-        let mut session_token = None;
+        // Check GUC values first
+        let mut access_key_id = AWS_ACCESS_KEY_ID.get().map(|s| {
+            let key = s.to_string_lossy().to_string();
+            eprintln!("DEBUG: GUC access_key_id: '{}'", key);
+            key
+        });
+        let mut secret_access_key = AWS_SECRET_ACCESS_KEY
+            .get()
+            .map(|s| s.to_string_lossy().to_string());
+        let mut session_token = AWS_SESSION_TOKEN
+            .get()
+            .map(|s| s.to_string_lossy().to_string());
+        let mut endpoint_url = AWS_ENDPOINT_URL
+            .get()
+            .map(|s| s.to_string_lossy().to_string());
+        let mut region = AWS_REGION.get().map(|s| s.to_string_lossy().to_string());
         let mut expire_at = None;
 
-        if let Some(credential_provider) = sdk_config.credentials_provider() {
-            let cred_res = PG_BACKEND_TOKIO_RUNTIME
-                .block_on(async { credential_provider.provide_credentials().await });
+        // If GUCs are not set, fall back to environment variables and config files
+        if access_key_id.is_none() || secret_access_key.is_none() {
+            let sdk_config = PG_BACKEND_TOKIO_RUNTIME
+                .block_on(async { aws_config::defaults(BehaviorVersion::latest()).load().await });
 
-            if let Ok(credentials) = cred_res {
-                access_key_id = Some(credentials.access_key_id().to_string());
-                secret_access_key = Some(credentials.secret_access_key().to_string());
-                session_token = credentials.session_token().map(|t| t.to_string());
-                expire_at = credentials.expiry();
-            } else {
-                pgrx::error!(
-                    "failed to load aws credentials: {:?}",
-                    cred_res.unwrap_err()
-                );
+            if let Some(credential_provider) = sdk_config.credentials_provider() {
+                let cred_res = PG_BACKEND_TOKIO_RUNTIME
+                    .block_on(async { credential_provider.provide_credentials().await });
+
+                if let Ok(credentials) = cred_res {
+                    if access_key_id.is_none() {
+                        let key = credentials.access_key_id().to_string();
+                        eprintln!("DEBUG: AWS SDK access_key_id: '{}'", key);
+                        access_key_id = Some(key);
+                    }
+                    if secret_access_key.is_none() {
+                        secret_access_key = Some(credentials.secret_access_key().to_string());
+                    }
+                    if session_token.is_none() {
+                        session_token = credentials.session_token().map(|t| t.to_string());
+                    }
+                    expire_at = credentials.expiry();
+                } else {
+                    pgrx::error!(
+                        "failed to load aws credentials: {:?}",
+                        cred_res.unwrap_err()
+                    );
+                }
             }
         }
 
-        let endpoint_url = sdk_config.endpoint_url().map(|u| u.to_string());
+        if region.is_none() {
+            let sdk_config = PG_BACKEND_TOKIO_RUNTIME
+                .block_on(async { aws_config::defaults(BehaviorVersion::latest()).load().await });
+            region = sdk_config.region().map(|r| r.to_string());
+        }
 
-        let region = sdk_config.region().map(|r| r.as_ref().to_string());
+        if endpoint_url.is_none() {
+            if let Ok(env_endpoint) = std::env::var("AWS_ENDPOINT_URL") {
+                endpoint_url = Some(env_endpoint);
+            }
+        }
 
         Self {
             region,

--- a/src/object_store/aws.rs
+++ b/src/object_store/aws.rs
@@ -129,7 +129,6 @@ impl AwsS3Config {
         // Check GUC values first
         let mut access_key_id = AWS_ACCESS_KEY_ID.get().map(|s| {
             let key = s.to_string_lossy().to_string();
-            eprintln!("DEBUG: GUC access_key_id: '{}'", key);
             key
         });
         let mut secret_access_key = AWS_SECRET_ACCESS_KEY
@@ -142,6 +141,7 @@ impl AwsS3Config {
             .get()
             .map(|s| s.to_string_lossy().to_string());
         let mut region = AWS_REGION.get().map(|s| s.to_string_lossy().to_string());
+        //ToDo: Add credential expiry handling when using session variables.
         let mut expire_at = None;
 
         // If GUCs are not set, fall back to environment variables and config files
@@ -156,7 +156,6 @@ impl AwsS3Config {
                 if let Ok(credentials) = cred_res {
                     if access_key_id.is_none() {
                         let key = credentials.access_key_id().to_string();
-                        eprintln!("DEBUG: AWS SDK access_key_id: '{}'", key);
                         access_key_id = Some(key);
                     }
                     if secret_access_key.is_none() {

--- a/src/object_store/gcs.rs
+++ b/src/object_store/gcs.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use object_store::gcp::GoogleCloudStorageBuilder;
 use url::Url;
 
+use crate::GOOGLE_SERVICE_ACCOUNT_KEY;
+
 use super::object_store_cache::ObjectStoreWithExpiration;
 
 // create_gcs_object_store a GoogleCloudStorage object store from given uri.
@@ -61,8 +63,15 @@ struct GoogleStorageConfig {
 impl GoogleStorageConfig {
     // load loads the Google Storage configuration from the environment.
     fn load() -> Self {
+        let mut key = GOOGLE_SERVICE_ACCOUNT_KEY
+            .get()
+            .map(|s| s.to_string_lossy().to_string());
+
+        if key.is_none() {
+            key = std::env::var("GOOGLE_SERVICE_ACCOUNT_KEY").ok();
+        }
         Self {
-            service_account_key: std::env::var("GOOGLE_SERVICE_ACCOUNT_KEY").ok(),
+            service_account_key: key,
             service_account_path: std::env::var("GOOGLE_SERVICE_ACCOUNT_PATH").ok(),
         }
     }


### PR DESCRIPTION
**Description**:

This PR adds PostgreSQL session variables to enable client-side credential management for AWS S3 and Google Cloud Storage, shifting credential control from server administrators to individual clients and applications.

1. AWS S3 Session Variables

- pg_parquet.aws_access_key_id - AWS access key ID
- pg_parquet.aws_secret_access_key - AWS secret access key
- pg_parquet.aws_session_token - AWS session token (for temporary credentials)
- pg_parquet.aws_region - AWS region for S3 operations
- pg_parquet.aws_endpoint_url - Custom endpoint for S3-compatible storage

2. Google Cloud Storage Session Variables

- pg_parquet.google_service_account_key - Service account key as JSON string

This PR is still work in progress. Will be adding similar session variables for azure as well.

I have created this for early feedback about the approach and implementation.

Closes: #161 and #129